### PR TITLE
updated pom.xml to pull kafka from mirror and unpack to the project build (target) directory

### DIFF
--- a/resource-monitor/pom.xml
+++ b/resource-monitor/pom.xml
@@ -13,7 +13,13 @@
         <module>metrics-persistence-api</module>
     </modules>
 
-    <properties></properties>
+    <properties>
+        <download-maven-plugin.version>1.5.0</download-maven-plugin.version>
+        <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <kafka.version>2.4.0</kafka.version>
+        <kafka-scala.version>2.12</kafka-scala.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -29,6 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -46,8 +53,48 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>${download-maven-plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>install-kafka</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>http://apache.claz.org/kafka/${kafka.version}/kafka_${kafka-scala.version}-${kafka.version}.tgz</url>
+                            <unpack>false</unpack>
+                            <outputDirectory>${project.build.directory}/kafka</outputDirectory>
+                            <sha512>53b52f86ea56c9fac62046524f03f75665a089ea2dae554aefe3a3d2694f2da88b5ba8725d8be55f198ba80695443559ed9de7c0b2a2817f7a6141008ff79f49</sha512>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven-antrun-plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>install-kafka</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target>
+                                <untar src="target/kafka/kafka_${kafka-scala.version}-${kafka.version}.tgz" dest="target/kafka" compression="gzip" />
+                                <delete file="target/kafka/kafka_${kafka-scala.version}-${kafka.version}.tgz" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/resource-monitor/pom.xml
+++ b/resource-monitor/pom.xml
@@ -66,7 +66,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>http://apache.claz.org/kafka/${kafka.version}/kafka_${kafka-scala.version}-${kafka.version}.tgz</url>
+                            <url>http://mirror.cc.columbia.edu/pub/software/apache/kafka/${kafka.version}/kafka_${kafka-scala.version}-${kafka.version}.tgz</url>
                             <unpack>false</unpack>
                             <outputDirectory>${project.build.directory}/kafka</outputDirectory>
                             <sha512>53b52f86ea56c9fac62046524f03f75665a089ea2dae554aefe3a3d2694f2da88b5ba8725d8be55f198ba80695443559ed9de7c0b2a2817f7a6141008ff79f49</sha512>


### PR DESCRIPTION
I updated the pom to pull the kafka archive from an apache mirror on a "install" build goal and unpack the tar archive into the target directory. Later on, we can add a plugin that will zip up the desired directories in "target" to a final zip, which will include kafka. The plugin will cache the kafka tar, so only the first build will be slow, subsequent builds will use your local cached copy. Here is what the "target" directory will look like: 


![kafka-build](https://user-images.githubusercontent.com/22966320/75377490-f44db880-589f-11ea-88bf-c08c52d1072d.PNG)