### PR TITLE
System metrics methods

### DIFF
--- a/resource-monitor/metrics-collector/pom.xml
+++ b/resource-monitor/metrics-collector/pom.xml
@@ -11,14 +11,16 @@
 
     <artifactId>metrics-collector</artifactId>
 
-    <properties></properties>
+    <properties>
+        <oshi.version>4.5.0</oshi.version>
+    </properties>
 
     <dependencies>
         <!-- https://mvnrepository.com/artifact/com.github.oshi/oshi-core -->
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>4.3.1</version>
+            <version>${oshi.version}</version>
         </dependency>
 
     </dependencies>

--- a/resource-monitor/metrics-collector/pom.xml
+++ b/resource-monitor/metrics-collector/pom.xml
@@ -13,14 +13,44 @@
 
     <properties>
         <oshi.version>4.5.0</oshi.version>
+        <spring-kafka.version>2.4.4.RELEASE</spring-kafka.version>
+        <kafka-junit4.version>3.2.1</kafka-junit4.version>
+        <jackson-core.version>2.10.3</jackson-core.version>
     </properties>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/com.github.oshi/oshi-core -->
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
             <version>${oshi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+            <version>${spring-kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.salesforce.kafka.test</groupId>
+            <artifactId>kafka-junit4</artifactId>
+            <version>${kafka-junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka-scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricRecord.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricRecord.java
@@ -1,0 +1,10 @@
+package edu.marist.mscs710.metricscollector;
+
+import edu.marist.mscs710.metricscollector.metric.Metric;
+
+import java.util.List;
+
+public interface MetricRecord {
+
+  List<? extends Metric> toMetricRecords();
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricRecord.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricRecord.java
@@ -4,7 +4,16 @@ import edu.marist.mscs710.metricscollector.metric.Metric;
 
 import java.util.List;
 
+/**
+ * Provides a common interface to convert metric data associated with a certain
+ * type to generic <tt>Metric</tt> objects. This is useful for serializing
+ * data in a generic format for use by various sources.
+ */
 public interface MetricRecord {
 
+  /**
+   * Extracts metric data in a generic format.
+   * @return list of generic <tt>Metric</tt> objects
+   */
   List<? extends Metric> toMetricRecords();
 }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricSource.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricSource.java
@@ -1,0 +1,10 @@
+package edu.marist.mscs710.metricscollector;
+
+import edu.marist.mscs710.metricscollector.data.MetricData;
+
+import java.util.List;
+
+public interface MetricSource {
+
+  List<? extends MetricData> getMetricData();
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricSource.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricSource.java
@@ -4,7 +4,16 @@ import edu.marist.mscs710.metricscollector.data.MetricData;
 
 import java.util.List;
 
+/**
+ * Provides a common interface to extract metric data from various sources
+ * in a system.
+ */
 public interface MetricSource {
 
+  /**
+   * Gets metric data from a system. The data returned is a snapshot of data
+   * aggregated since the last time this method was called.
+   * @return list of <tt>MetricData</tt> objects
+   */
   List<? extends MetricData> getMetricData();
 }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricsProducer.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricsProducer.java
@@ -1,0 +1,20 @@
+package edu.marist.mscs710.metricscollector;
+
+public interface MetricsProducer {
+
+  boolean start();
+
+  boolean pause(int seconds);
+
+  boolean wakeup();
+
+  boolean setFrequency(int seconds);
+
+  int getFrequency();
+
+  boolean isStarted();
+
+  long getNextProduceTime();
+
+  void shutdown();
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricsProducer.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/MetricsProducer.java
@@ -1,20 +1,58 @@
 package edu.marist.mscs710.metricscollector;
 
+/**
+ * Provides a common interface to interact with producer of system metrics.
+ */
 public interface MetricsProducer {
 
+  /**
+   * Start collection of metrics.
+   * @return true if the operation is successful, false otherwise
+   */
   boolean start();
 
+  /**
+   * Pause collection of metrics for the specified number of seconds. A negative
+   * value will cause metric collection to pause indefinitely. This value should
+   * not be zero.
+   * @param seconds number of seconds to pause
+   * @return true if the operation is successful, false otherwise
+   */
   boolean pause(int seconds);
 
+  /**
+   * Restarts metric collection if the producer is paused indefinitely.
+   * @return true if the operation is successful, false otherwise
+   */
   boolean wakeup();
 
+  /**
+   * Sets the frequency of metric collection.
+   * @param seconds number of seconds between metric collection operations
+   * @return true if the operation is successful, false otherwise
+   */
   boolean setFrequency(int seconds);
 
+  /**
+   * Gets the current frequency.
+   * @return seconds between metric collection operations
+   */
   int getFrequency();
 
+  /**
+   * Checks if the <tt>MetricsProducer</tt> has started.
+   * @return true if the <tt>MetricsProducer</tt> has started, false otherwise
+   */
   boolean isStarted();
 
+  /**
+   * Gets the epoch milli timestamp of the next scheduled metric collection operation.
+   * @return
+   */
   long getNextProduceTime();
 
+  /**
+   * Stops the <tt>MetricsProducer</tt>
+   */
   void shutdown();
 }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/SourceCodeFile.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/SourceCodeFile.java
@@ -1,4 +1,0 @@
-package edu.marist.mscs710.metricscollector;
-
-public class SourceCodeFile {
-}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/CpuData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/CpuData.java
@@ -6,11 +6,23 @@ import edu.marist.mscs710.metricscollector.metric.MetricType;
 
 import java.util.*;
 
+/**
+ * Holds a snapshot of CPU data. CPU usage metrics are given as percent
+ * utilization from 0.0-1.0.
+ */
 public class CpuData extends MetricData {
   private double[] cpuCoreUsages; // Per core cpu usage during previous delta millis
   private double totalCpuUsage; // Total cpu usage during previous delta millis
   private double cpuTemp; // degrees C, 0.0 if not available, need elevated permissions in Windows
 
+  /**
+   * Constructs a new <tt>CpuData</tt> with the supplied metrics.
+   * @param cpuCoreUsages array of doubles representing CPU usages during this snapshot
+   * @param totalCpuUsage overall CPU usage during this snapshot
+   * @param cpuTemp cpu temperature in degrees Celsius
+   * @param deltaMillis time covered by this snapshot
+   * @param epochMillisTime epoch milli timestamp of this snapshot
+   */
   public CpuData(double[] cpuCoreUsages, double totalCpuUsage, double cpuTemp, long deltaMillis, long epochMillisTime) {
     this.cpuCoreUsages = cpuCoreUsages;
     this.totalCpuUsage = totalCpuUsage;
@@ -19,14 +31,27 @@ public class CpuData extends MetricData {
     this.epochMillisTime = epochMillisTime;
   }
 
+  /**
+   * Gets the array of CPU core usages. ID is given by array index.
+   * @return double[] of cpu core usages
+   */
   public double[] getCpuCoreUsages() {
     return cpuCoreUsages;
   }
 
+  /**
+   * Gets the overall CPU usage.
+   * @return overall CPU usage
+   */
   public double getTotalCpuUsage() {
     return totalCpuUsage;
   }
 
+  /**
+   * Gets the CPU temperature.
+   * @return CPU temperature in degrees Celsius, at epochMillisTime,
+   * or 0.0 if unavailable
+   */
   public double getCpuTemp() {
     return cpuTemp;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/CpuData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/CpuData.java
@@ -46,6 +46,7 @@ public class CpuData extends MetricData {
     return new HashMap<String, Object>() {
       {
         put(Fields.Cpu.DATETIME.toString(), epochMillisTime);
+        put(Fields.Cpu.DELTA_MILLIS.toString(), deltaMillis);
         put(Fields.Cpu.TEMPERATURE.toString(), cpuTemp);
         put(Fields.Cpu.UTILIZATION.toString(), totalCpuUsage);
       }
@@ -61,6 +62,7 @@ public class CpuData extends MetricData {
       coreMaps.add(new HashMap<String, Object>() {
         {
           put(Fields.CpuCore.DATETIME.toString(), epochMillisTime);
+          put(Fields.CpuCore.DELTA_MILLIS.toString(), deltaMillis);
           put(Fields.CpuCore.CORE_ID.toString(), coreId);
           put(Fields.CpuCore.CORE_UTILIZATION.toString(), cpuCoreUsages[coreId]);
         }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/CpuData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/CpuData.java
@@ -1,0 +1,85 @@
+package edu.marist.mscs710.metricscollector.data;
+
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+
+import java.util.*;
+
+public class CpuData extends MetricData {
+  private double[] cpuCoreUsages; // Per core cpu usage during previous delta millis
+  private double totalCpuUsage; // Total cpu usage during previous delta millis
+  private double cpuTemp; // degrees C, 0.0 if not available, need elevated permissions in Windows
+
+  public CpuData(double[] cpuCoreUsages, double totalCpuUsage, double cpuTemp, long deltaMillis, long epochMillisTime) {
+    this.cpuCoreUsages = cpuCoreUsages;
+    this.totalCpuUsage = totalCpuUsage;
+    this.cpuTemp = cpuTemp;
+    this.deltaMillis = deltaMillis;
+    this.epochMillisTime = epochMillisTime;
+  }
+
+  public double[] getCpuCoreUsages() {
+    return cpuCoreUsages;
+  }
+
+  public double getTotalCpuUsage() {
+    return totalCpuUsage;
+  }
+
+  public double getCpuTemp() {
+    return cpuTemp;
+  }
+
+  @Override
+  public String toString() {
+    return "CpuData{" +
+      "cpuCoreUsages=" + Arrays.toString(cpuCoreUsages) +
+      ", totalCpuUsage=" + totalCpuUsage +
+      ", cpuTemp=" + cpuTemp +
+      ", deltaMillis=" + deltaMillis +
+      ", epochMillisTime=" + epochMillisTime +
+      '}';
+  }
+
+  private Map<String, Object> getCpuMap() {
+    return new HashMap<String, Object>() {
+      {
+        put(Fields.Cpu.DATETIME.toString(), epochMillisTime);
+        put(Fields.Cpu.TEMPERATURE.toString(), cpuTemp);
+        put(Fields.Cpu.UTILIZATION.toString(), totalCpuUsage);
+      }
+    };
+  }
+
+  private List<Map<String, Object>> getCpuCoreMaps() {
+    int numCores = cpuCoreUsages.length;
+    List<Map<String, Object>> coreMaps = new ArrayList<>(numCores);
+
+    for (int i = 0; i < numCores; i++) {
+      int coreId = i;
+      coreMaps.add(new HashMap<String, Object>() {
+        {
+          put(Fields.CpuCore.DATETIME.toString(), epochMillisTime);
+          put(Fields.CpuCore.CORE_ID.toString(), coreId);
+          put(Fields.CpuCore.CORE_UTILIZATION.toString(), cpuCoreUsages[coreId]);
+        }
+      });
+    }
+
+    return coreMaps;
+  }
+
+  @Override
+  public List<Metric> toMetricRecords() {
+    List<Metric> cpuRecords = new ArrayList<>();
+
+    cpuRecords.add(new Metric(MetricType.CPU, getCpuMap()));
+
+    for (Map<String, Object> cpuCoreMap : getCpuCoreMaps()) {
+      cpuRecords.add(new Metric(MetricType.CPU_CORE, cpuCoreMap));
+    }
+
+    return cpuRecords;
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MemoryData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MemoryData.java
@@ -42,6 +42,7 @@ public class MemoryData extends MetricData {
     return new HashMap<String, Object>() {
       {
         put(Fields.Memory.DATETIME.toString(), epochMillisTime);
+        put(Fields.Memory.DELTA_MILLIS.toString(), deltaMillis);
         put(Fields.Memory.UTILIZATION.toString(), memoryUtilization);
         put(Fields.Memory.PAGE_FAULTS.toString(), ((double) pageFaults) / deltaMillis * 1000.0);
       }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MemoryData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MemoryData.java
@@ -9,10 +9,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Holds a snapshot of Memory data.
+ */
 public class MemoryData extends MetricData {
   private double memoryUtilization; // Pct memory in use
   private long pageFaults; // during time span delta millis
 
+  /**
+   * Constructs a new <tt>MemoryData</tt> with the supplied metrics.
+   * @param memoryUtilization memory utilization from 0.0-1.0
+   * @param pageFaults number of page faults during this snapshot
+   * @param deltaMillis time covered by this snapshot
+   * @param epochMillisTime epoch milli timestamp of this snapshot
+   */
   public MemoryData(double memoryUtilization, long pageFaults, long deltaMillis, long epochMillisTime) {
     this.memoryUtilization = memoryUtilization;
     this.pageFaults = pageFaults;
@@ -20,10 +30,18 @@ public class MemoryData extends MetricData {
     this.epochMillisTime = epochMillisTime;
   }
 
+  /**
+   * Gets the memory utilization.
+   * @return overall memory utilization.
+   */
   public double getMemoryUtilization() {
     return memoryUtilization;
   }
 
+  /**
+   * Gets the number of page faults during this snapshot
+   * @return number of page faults
+   */
   public long getPageFaults() {
     return pageFaults;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MemoryData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MemoryData.java
@@ -1,0 +1,55 @@
+package edu.marist.mscs710.metricscollector.data;
+
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MemoryData extends MetricData {
+  private double memoryUtilization; // Pct memory in use
+  private long pageFaults; // during time span delta millis
+
+  public MemoryData(double memoryUtilization, long pageFaults, long deltaMillis, long epochMillisTime) {
+    this.memoryUtilization = memoryUtilization;
+    this.pageFaults = pageFaults;
+    this.deltaMillis = deltaMillis;
+    this.epochMillisTime = epochMillisTime;
+  }
+
+  public double getMemoryUtilization() {
+    return memoryUtilization;
+  }
+
+  public long getPageFaults() {
+    return pageFaults;
+  }
+
+  @Override
+  public String toString() {
+    return "MemoryData{" +
+      "memoryUtilization=" + memoryUtilization +
+      ", pageFaults=" + pageFaults +
+      ", deltaMillis=" + deltaMillis +
+      ", epochMillisTime=" + epochMillisTime +
+      '}';
+  }
+
+  private Map<String, Object> getMemoryMap() {
+    return new HashMap<String, Object>() {
+      {
+        put(Fields.Memory.DATETIME.toString(), epochMillisTime);
+        put(Fields.Memory.UTILIZATION.toString(), memoryUtilization);
+        put(Fields.Memory.PAGE_FAULTS.toString(), ((double) pageFaults) / deltaMillis * 1000.0);
+      }
+    };
+  }
+
+  @Override
+  public List<Metric> toMetricRecords() {
+    return Collections.singletonList(new Metric(MetricType.MEMORY, getMemoryMap()));
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MetricData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MetricData.java
@@ -1,0 +1,16 @@
+package edu.marist.mscs710.metricscollector.data;
+
+import edu.marist.mscs710.metricscollector.MetricRecord;
+
+public abstract class MetricData implements MetricRecord {
+  protected long deltaMillis;
+  protected long epochMillisTime;
+
+  public long getDeltaMillis() {
+    return deltaMillis;
+  }
+
+  public long getEpochMillisTime() {
+    return epochMillisTime;
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MetricData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/MetricData.java
@@ -2,14 +2,25 @@ package edu.marist.mscs710.metricscollector.data;
 
 import edu.marist.mscs710.metricscollector.MetricRecord;
 
+/**
+ * Abstract base class for all other <tt>MetricData</tt> objects.
+ */
 public abstract class MetricData implements MetricRecord {
   protected long deltaMillis;
   protected long epochMillisTime;
 
+  /**
+   * Gets time in milliseconds covered by this snapshot.
+   * @return number of milliseconds
+   */
   public long getDeltaMillis() {
     return deltaMillis;
   }
 
+  /**
+   * Gets the time epoch milli timestamp of this snapshot.
+   * @return epoch milli timestamp
+   */
   public long getEpochMillisTime() {
     return epochMillisTime;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/NetworkData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/NetworkData.java
@@ -9,6 +9,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Holds a snapshot of Network data.
+ */
 public class NetworkData extends MetricData {
   private static final long BITS_PER_KILOBIT = 1000L;
   private static final int BITS_PER_BYTE = 8;
@@ -16,6 +19,14 @@ public class NetworkData extends MetricData {
   private long bytesRecv; // During delta millis
   private long speed; // Bits per second network capacity, sum over active network interfaces
 
+  /**
+   * Constructs a new <tt>NetworkData</tt> with the supplied metrics.
+   * @param bytesSent number of bytes sent during this snapshot
+   * @param bytesRecv number of bytes received during this snapshot
+   * @param speed total network capacity over active network interfaces in bits per second
+   * @param deltaMillis time covered by this snapshot
+   * @param epochMillisTime epoch milli timestamp of this snapshot
+   */
   public NetworkData(long bytesSent, long bytesRecv, long speed, long deltaMillis, long epochMillisTime) {
     this.bytesSent = bytesSent;
     this.bytesRecv = bytesRecv;
@@ -24,14 +35,27 @@ public class NetworkData extends MetricData {
     this.epochMillisTime = epochMillisTime;
   }
 
+  /**
+   * Gets the bytes sent during this snapshot
+   * @return number of bytes
+   */
   public long getBytesSent() {
     return bytesSent;
   }
 
+  /**
+   * Gets the bytes received during this snapshot
+   * @return number of bytes
+   */
   public long getBytesRecv() {
     return bytesRecv;
   }
 
+  /**
+   * Gets the total network capacity over active network interfaces in bits per second.
+   * A network interface is considered inactive after five minutes of inactivity.
+   * @return speed in bits per second
+   */
   public long getSpeed() {
     return speed;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/NetworkData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/NetworkData.java
@@ -1,0 +1,65 @@
+package edu.marist.mscs710.metricscollector.data;
+
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NetworkData extends MetricData {
+  private static final long BITS_PER_KILOBIT = 1000L;
+  private static final int BITS_PER_BYTE = 8;
+  private long bytesSent; // During delta millis
+  private long bytesRecv; // During delta millis
+  private long speed; // Bits per second network capacity, sum over active network interfaces
+
+  public NetworkData(long bytesSent, long bytesRecv, long speed, long deltaMillis, long epochMillisTime) {
+    this.bytesSent = bytesSent;
+    this.bytesRecv = bytesRecv;
+    this.speed = speed;
+    this.deltaMillis = deltaMillis;
+    this.epochMillisTime = epochMillisTime;
+  }
+
+  public long getBytesSent() {
+    return bytesSent;
+  }
+
+  public long getBytesRecv() {
+    return bytesRecv;
+  }
+
+  public long getSpeed() {
+    return speed;
+  }
+
+  @Override
+  public String toString() {
+    return "NetworkData{" +
+      "bytesSent=" + bytesSent +
+      ", bytesRecv=" + bytesRecv +
+      ", speed=" + speed +
+      ", deltaMillis=" + deltaMillis +
+      ", epochMillisTime=" + epochMillisTime +
+      '}';
+  }
+
+  private Map<String, Object> getNetworkMap() {
+    return new HashMap<String, Object>() {
+      {
+        put(Fields.Network.DATETIME.toString(), epochMillisTime);
+        put(Fields.Network.THROUGHPUT.toString(), speed / BITS_PER_KILOBIT);
+        put(Fields.Network.SEND.toString(), ((double) bytesSent) / deltaMillis * BITS_PER_BYTE);
+        put(Fields.Network.RECEIVE.toString(), ((double) bytesRecv) / deltaMillis * BITS_PER_BYTE);
+      }
+    };
+  }
+
+  @Override
+  public List<Metric> toMetricRecords() {
+    return Collections.singletonList(new Metric(MetricType.NETWORK, getNetworkMap()));
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/NetworkData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/NetworkData.java
@@ -51,6 +51,7 @@ public class NetworkData extends MetricData {
     return new HashMap<String, Object>() {
       {
         put(Fields.Network.DATETIME.toString(), epochMillisTime);
+        put(Fields.Network.DELTA_MILLIS.toString(), deltaMillis);
         put(Fields.Network.THROUGHPUT.toString(), speed / BITS_PER_KILOBIT);
         put(Fields.Network.SEND.toString(), ((double) bytesSent) / deltaMillis * BITS_PER_BYTE);
         put(Fields.Network.RECEIVE.toString(), ((double) bytesRecv) / deltaMillis * BITS_PER_BYTE);

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/ProcessData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/ProcessData.java
@@ -105,6 +105,7 @@ public class ProcessData extends MetricData {
     return new HashMap<String, Object>() {
       {
         put(Fields.Processes.DATETIME.toString(), epochMillisTime);
+        put(Fields.Processes.DELTA_MILLIS.toString(), deltaMillis);
         put(Fields.Processes.PID.toString(), pid);
         put(Fields.Processes.NAME.toString(), name);
         put(Fields.Processes.START_TIME.toString(), startTime);

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/ProcessData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/ProcessData.java
@@ -1,0 +1,125 @@
+package edu.marist.mscs710.metricscollector.data;
+
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+import edu.marist.mscs710.metricscollector.system.Processes;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProcessData extends MetricData {
+  private static final long BYTES_PER_KB = 1024L;
+  private int pid;
+  private String name;
+  private long startTime; // Unix time millis
+  private long upTime; // millis
+  private double cpuUsage; // During previous delta millis
+  private long memory; // Total bytes allocated to process and in RAM
+  private long bytesRead; // Bytes read from disk during previous delta millis
+  private long bytesWritten; // During previous delta millis
+  private Processes.PidState pidState;
+
+  public ProcessData(int pid, String name, long startTime, long upTime,
+                     double cpuUsage, long memory, long bytesRead, long bytesWritten,
+                     Processes.PidState pidState, long deltaMillis, long epochMillisTime) {
+    this.pid = pid;
+    this.name = name;
+    this.startTime = startTime;
+    this.upTime = upTime;
+    this.cpuUsage = cpuUsage;
+    this.memory = memory;
+    this.bytesRead = bytesRead;
+    this.bytesWritten = bytesWritten;
+    this.deltaMillis = deltaMillis;
+    this.pidState = pidState;
+    this.epochMillisTime = epochMillisTime;
+  }
+
+  public ProcessData(int pid, String name, long epochMillisTime) {
+    this(pid, name, -1, -1, -1, -1, -1, -1, Processes.PidState.ENDED, -1, epochMillisTime);
+  }
+
+  public int getPid() {
+    return pid;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getUpTime() {
+    return upTime;
+  }
+
+  public double getCpuUsage() {
+    return cpuUsage;
+  }
+
+  public long getMemory() {
+    return memory;
+  }
+
+  public long getBytesRead() {
+    return bytesRead;
+  }
+
+  public long getBytesWritten() {
+    return bytesWritten;
+  }
+
+  public Processes.PidState getPidState() {
+    return pidState;
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessData{" +
+      "pid=" + pid +
+      ", name='" + name + '\'' +
+      ", startTime=" + startTime +
+      ", upTime=" + upTime +
+      ", cpuUsage=" + cpuUsage +
+      ", memory=" + memory +
+      ", bytesRead=" + bytesRead +
+      ", bytesWritten=" + bytesWritten +
+      ", pidState=" + pidState +
+      ", deltaMillis=" + deltaMillis +
+      ", epochMillisTime=" + epochMillisTime +
+      '}';
+  }
+
+  private Map<String, Object> getProcessMap() {
+    boolean isEndedState = pidState == Processes.PidState.ENDED;
+
+    long kbMemory = isEndedState ? -1 : memory / BYTES_PER_KB;
+    double kbRead = isEndedState ? -1 : ((double) bytesRead) / deltaMillis;
+    double kbWritten = isEndedState ? -1 : ((double) bytesWritten) / deltaMillis;
+
+    return new HashMap<String, Object>() {
+      {
+        put(Fields.Processes.DATETIME.toString(), epochMillisTime);
+        put(Fields.Processes.PID.toString(), pid);
+        put(Fields.Processes.NAME.toString(), name);
+        put(Fields.Processes.START_TIME.toString(), startTime);
+        put(Fields.Processes.UPTIME.toString(), upTime);
+        put(Fields.Processes.CPU_USAGE.toString(), cpuUsage);
+        put(Fields.Processes.MEMORY.toString(), kbMemory);
+        put(Fields.Processes.KB_READ.toString(), kbRead);
+        put(Fields.Processes.KB_WRITTEN.toString(), kbWritten);
+        put(Fields.Processes.STATE.toString(), pidState.toString());
+      }
+    };
+  }
+
+  @Override
+  public List<Metric> toMetricRecords() {
+    return Collections.singletonList(new Metric(MetricType.PROCESSES, getProcessMap()));
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/ProcessData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/ProcessData.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Holds a snapshot of Process data.
+ */
 public class ProcessData extends MetricData {
   private static final long BYTES_PER_KB = 1024L;
   private int pid;
@@ -22,6 +25,20 @@ public class ProcessData extends MetricData {
   private long bytesWritten; // During previous delta millis
   private Processes.PidState pidState;
 
+  /**
+   * Constructs a new <tt>ProcessData</tt> with the supplied metrics.
+   * @param pid process id
+   * @param name name of the process
+   * @param startTime start time of process as epoch milli timestamp
+   * @param upTime number of milliseconds the process has been running
+   * @param cpuUsage cpu usage of the process during this snapshot
+   * @param memory total bytes allocated to this process and in RAM
+   * @param bytesRead total bytes read from disk during this snapshot
+   * @param bytesWritten total bytes written to disk during this snapshot
+   * @param pidState state of the process
+   * @param deltaMillis time covered by this snapshot
+   * @param epochMillisTime epoch milli timestamp of this snapshot
+   */
   public ProcessData(int pid, String name, long startTime, long upTime,
                      double cpuUsage, long memory, long bytesRead, long bytesWritten,
                      Processes.PidState pidState, long deltaMillis, long epochMillisTime) {
@@ -38,42 +55,84 @@ public class ProcessData extends MetricData {
     this.epochMillisTime = epochMillisTime;
   }
 
+  /**
+   * Constructs a new <tt>ProcessData</tt> with state <tt>Processes.PidState.ENDED</tt>
+   * @param pid process id
+   * @param name name of the process
+   * @param epochMillisTime epoch milli timestamp of this snapshot
+   */
   public ProcessData(int pid, String name, long epochMillisTime) {
     this(pid, name, -1, -1, -1, -1, -1, -1, Processes.PidState.ENDED, -1, epochMillisTime);
   }
 
+  /**
+   * Gets the process id.
+   * @return process id
+   */
   public int getPid() {
     return pid;
   }
 
+  /**
+   * Gets the process name.
+   * @return process name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Gets the process start time as epoch milli timestamp.
+   * @return start time
+   */
   public long getStartTime() {
     return startTime;
   }
 
+  /**
+   * Gets number of milliseconds the process has been running.
+   * @return milliseconds of uptime
+   */
   public long getUpTime() {
     return upTime;
   }
 
+  /**
+   * Gets the cpu usage of the process during this snapshot.
+   * @return cpu usage
+   */
   public double getCpuUsage() {
     return cpuUsage;
   }
 
+  /**
+   * Gets the total number of bytes allocated to this process and in RAM
+   * @return bytes of memory
+   */
   public long getMemory() {
     return memory;
   }
 
+  /**
+   * Gets the total number of bytes read from disk during this snapshot.
+   * @return bytes read
+   */
   public long getBytesRead() {
     return bytesRead;
   }
 
+  /**
+   * Gets the total number of bytes written to disk during this snapshot.
+   * @return bytes read
+   */
   public long getBytesWritten() {
     return bytesWritten;
   }
 
+  /**
+   * Gets the state of the process.
+   * @return process state
+   */
   public Processes.PidState getPidState() {
     return pidState;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/SystemData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/SystemData.java
@@ -1,0 +1,47 @@
+package edu.marist.mscs710.metricscollector.data;
+
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SystemData extends MetricData {
+  private long upTime; // Seconds since system boot
+
+  public SystemData(long upTime, long deltaMillis, long epochMillisTime) {
+    this.upTime = upTime;
+    this.deltaMillis = deltaMillis;
+    this.epochMillisTime = epochMillisTime;
+  }
+
+  public long getUpTime() {
+    return upTime;
+  }
+
+  @Override
+  public String toString() {
+    return "SystemData{" +
+      "upTime=" + upTime +
+      ", deltaMillis=" + deltaMillis +
+      ", epochMillisTime=" + epochMillisTime +
+      '}';
+  }
+
+  private Map<String, Object> getSystemDataMap() {
+    return new HashMap<String, Object>() {
+      {
+        put(Fields.SystemMetrics.DATETIME.toString(), epochMillisTime);
+        put(Fields.SystemMetrics.UPTIME.toString(), upTime);
+      }
+    };
+  }
+
+  @Override
+  public List<Metric> toMetricRecords() {
+    return Collections.singletonList(new Metric(MetricType.SYSTEM_METRICS, getSystemDataMap()));
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/SystemData.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/data/SystemData.java
@@ -9,15 +9,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Holds a snapshot of System data.
+ */
 public class SystemData extends MetricData {
   private long upTime; // Seconds since system boot
 
+  /**
+   * Constructs a new <tt>SystemData</tt> with the supplied metrics.
+   * @param upTime number of seconds since system boot
+   * @param deltaMillis time covered by this snapshot
+   * @param epochMillisTime epoch milli timestamp of this snapshot
+   */
   public SystemData(long upTime, long deltaMillis, long epochMillisTime) {
     this.upTime = upTime;
     this.deltaMillis = deltaMillis;
     this.epochMillisTime = epochMillisTime;
   }
 
+  /**
+   * Gets the uptime of the system.
+   * @return seconds since boot time
+   */
   public long getUpTime() {
     return upTime;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/KafkaConfig.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/KafkaConfig.java
@@ -14,20 +14,37 @@ import org.springframework.kafka.listener.MessageListener;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.function.Consumer;
 
+/**
+ * Configuration class of Kafka producers and consumers.
+ */
 public class KafkaConfig {
   private static final long DEFAULT_IDLE_BETWEEN_POLLS = 500; // ms
   private static final OffsetResetPolicy DEFAULT_OFFSET_RESET_POLICY = OffsetResetPolicy.EARLIEST;
 
+  /**
+   * Enum of auto offset reset policies supported by Kafka. This policy determines
+   * how a Kafka consumer behaves when there is no offset available. This primarily
+   * affects the behavior of a new consumer to a topic.
+   */
   public enum OffsetResetPolicy {
-    EARLIEST, // When starting new consumer group, read from earliest available message. We probably want this for the database.
-    LATEST,  // When starting new consumer group, read from latest available message. We probably want this for UI live data.
-    NONE // Have to implement our own policy, otherwise will throw exception.
+    /**
+     * Read from the earliest available message on the topic.
+     */
+    EARLIEST, // We probably want this for the database.
+    /**
+     * Read from the latest available message.
+     */
+    LATEST,  // We probably want this for UI live data.
+    /**
+     * No policy. Consumers have to implement a custom policy, otherwise the
+     * consumer throws an exception.
+     */
+    NONE
   }
 
-  public static Map<String, Object> createProducerProps(List<String> kafkaBrokers) {
+  private static Map<String, Object> createProducerProps(List<String> kafkaBrokers) {
     Map<String, Object> props = new HashMap<>();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, String.join(",", kafkaBrokers));
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -36,15 +53,23 @@ public class KafkaConfig {
     return props;
   }
 
-  public static ProducerFactory<String, Metric> createProducerFactory(List<String> kafkaBrokers) {
+  private static ProducerFactory<String, Metric> createProducerFactory(List<String> kafkaBrokers) {
     return new DefaultKafkaProducerFactory<>(createProducerProps(kafkaBrokers));
   }
 
+  /**
+   * Creates Kafka template configured to produce <tt>Metric</tt> messages to
+   * the given list of Kafka brokers.
+   * @param kafkaBrokers List of Kafka broker connection strings, in the form
+   *                     of host:port
+   * @return Kafka template configured to send <tt>Metric</tt> messages with
+   * an optional <tt>String</tt> as a key.
+   */
   public static KafkaTemplate<String, Metric> createKafkaTemplate(List<String> kafkaBrokers) {
     return new KafkaTemplate<>(createProducerFactory(kafkaBrokers));
   }
 
-  public static Map<String, Object> createConsumerProps(List<String> kafkaBrokers, String consumerGroup,
+  private static Map<String, Object> createConsumerProps(List<String> kafkaBrokers, String consumerGroup,
                                                         OffsetResetPolicy resetPolicy) {
     Map<String, Object> props = new HashMap<>();
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, String.join(",", kafkaBrokers));
@@ -56,16 +81,38 @@ public class KafkaConfig {
     return props;
   }
 
-  public static ConsumerFactory<String, Metric> createConsumerFactory(List<String> kafkaBrokers, String consumerGroup, OffsetResetPolicy resetPolicy) {
+  private static ConsumerFactory<String, Metric> createConsumerFactory(List<String> kafkaBrokers, String consumerGroup, OffsetResetPolicy resetPolicy) {
     return new DefaultKafkaConsumerFactory<>(createConsumerProps(kafkaBrokers, consumerGroup, resetPolicy));
   }
 
+  /**
+   * Creates a Kafka message listener with <tt>OffsetResetPolicy.EARLIEST</tt> and
+   * idle between polls of 500 ms.
+   * @param kafkaBrokers list of Kafka brokers
+   * @param consumerGroup consumer group
+   * @param topic topic from which to consume messages
+   * @param dataConsumer <tt>Consumer</tt> functional interface, called on a
+   *                     successful receive of a message
+   * @return Kafka message listener
+   */
   public static KafkaMessageListenerContainer<String, Metric> createListener(List<String> kafkaBrokers, String consumerGroup, String topic,
                                                                            Consumer<ConsumerRecord<String, Metric>> dataConsumer) {
     return KafkaConfig.createListener(kafkaBrokers, consumerGroup, DEFAULT_OFFSET_RESET_POLICY,
       topic, DEFAULT_IDLE_BETWEEN_POLLS, dataConsumer);
   }
 
+  /**
+   * Creates a Kafka message listener with the supplied parameters.
+   * @param kafkaBrokers list of Kafka brokers
+   * @param consumerGroup consumer group
+   * @param resetPolicy consumer  auto offset reset policy
+   * @param topic topic from which to consume messages
+   * @param idleBetweenPolls number of milliseconds to wait between polls to get
+   *                         messages from Kafka
+   * @param dataConsumer <tt>Consumer</tt> functional interface, called on a
+   *    *                     successful receive of a message
+   * @return Kafka message listener
+   */
   public static KafkaMessageListenerContainer<String, Metric> createListener(List<String> kafkaBrokers, String consumerGroup,
                                                                            OffsetResetPolicy resetPolicy, String topic, long idleBetweenPolls,
                                                                            Consumer<ConsumerRecord<String, Metric>> dataConsumer) {

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/KafkaConfig.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/KafkaConfig.java
@@ -1,0 +1,79 @@
+package edu.marist.mscs710.metricscollector.kafka;
+
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.kafka.listener.MessageListener;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Consumer;
+
+public class KafkaConfig {
+  private static final long DEFAULT_IDLE_BETWEEN_POLLS = 500; // ms
+  private static final OffsetResetPolicy DEFAULT_OFFSET_RESET_POLICY = OffsetResetPolicy.EARLIEST;
+
+  public enum OffsetResetPolicy {
+    EARLIEST, // When starting new consumer group, read from earliest available message. We probably want this for the database.
+    LATEST,  // When starting new consumer group, read from latest available message. We probably want this for UI live data.
+    NONE // Have to implement our own policy, otherwise will throw exception.
+  }
+
+  public static Map<String, Object> createProducerProps(List<String> kafkaBrokers) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, String.join(",", kafkaBrokers));
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, MetricSerializer.class);
+
+    return props;
+  }
+
+  public static ProducerFactory<String, Metric> createProducerFactory(List<String> kafkaBrokers) {
+    return new DefaultKafkaProducerFactory<>(createProducerProps(kafkaBrokers));
+  }
+
+  public static KafkaTemplate<String, Metric> createKafkaTemplate(List<String> kafkaBrokers) {
+    return new KafkaTemplate<>(createProducerFactory(kafkaBrokers));
+  }
+
+  public static Map<String, Object> createConsumerProps(List<String> kafkaBrokers, String consumerGroup,
+                                                        OffsetResetPolicy resetPolicy) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, String.join(",", kafkaBrokers));
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, MetricDeserializer.class);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, resetPolicy.toString().toLowerCase());
+
+    return props;
+  }
+
+  public static ConsumerFactory<String, Metric> createConsumerFactory(List<String> kafkaBrokers, String consumerGroup, OffsetResetPolicy resetPolicy) {
+    return new DefaultKafkaConsumerFactory<>(createConsumerProps(kafkaBrokers, consumerGroup, resetPolicy));
+  }
+
+  public static KafkaMessageListenerContainer<String, Metric> createListener(List<String> kafkaBrokers, String consumerGroup, String topic,
+                                                                           Consumer<ConsumerRecord<String, Metric>> dataConsumer) {
+    return KafkaConfig.createListener(kafkaBrokers, consumerGroup, DEFAULT_OFFSET_RESET_POLICY,
+      topic, DEFAULT_IDLE_BETWEEN_POLLS, dataConsumer);
+  }
+
+  public static KafkaMessageListenerContainer<String, Metric> createListener(List<String> kafkaBrokers, String consumerGroup,
+                                                                           OffsetResetPolicy resetPolicy, String topic, long idleBetweenPolls,
+                                                                           Consumer<ConsumerRecord<String, Metric>> dataConsumer) {
+    ContainerProperties containerProps = new ContainerProperties(topic);
+    containerProps.setAckMode(ContainerProperties.AckMode.RECORD);
+    containerProps.setMessageListener((MessageListener<String, Metric>) dataConsumer::accept);
+    containerProps.setIdleBetweenPolls(idleBetweenPolls);
+
+    return new KafkaMessageListenerContainer<>(createConsumerFactory(kafkaBrokers, consumerGroup, resetPolicy), containerProps);
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricDeserializer.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricDeserializer.java
@@ -1,0 +1,22 @@
+package edu.marist.mscs710.metricscollector.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+import org.apache.kafka.common.serialization.Deserializer;
+
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class MetricDeserializer implements Deserializer<Metric> {
+
+  @Override
+  public Metric deserialize(String s, byte[] bytes) {
+    try {
+      return new ObjectMapper().readValue(bytes, Metric.class);
+    } catch (IOException ex) {
+      return new Metric(MetricType.NULL, new HashMap<>());
+    }
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricDeserializer.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricDeserializer.java
@@ -3,19 +3,28 @@ package edu.marist.mscs710.metricscollector.kafka;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.marist.mscs710.metricscollector.metric.Metric;
 import edu.marist.mscs710.metricscollector.metric.MetricType;
+import edu.marist.mscs710.metricscollector.utils.LoggerUtils;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 import java.io.IOException;
 import java.util.HashMap;
 
+/**
+ * Class to deserialize <tt>Metric</tt> objects from Kafka.
+ */
 public class MetricDeserializer implements Deserializer<Metric> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetricDeserializer.class);
+  private ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
   public Metric deserialize(String s, byte[] bytes) {
     try {
-      return new ObjectMapper().readValue(bytes, Metric.class);
+      return objectMapper.readValue(bytes, Metric.class);
     } catch (IOException ex) {
+      LOGGER.error(LoggerUtils.getExceptionMessage(ex));
       return new Metric(MetricType.NULL, new HashMap<>());
     }
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSender.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSender.java
@@ -5,22 +5,44 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 import java.util.List;
 
+/**
+ * Wrapper to <tt>KafkaTemplate</tt>
+ */
 public class MetricSender {
 
   private KafkaTemplate<String, Metric> kafkaTemplate;
 
+  /**
+   * Constructs a new <tt>MetricSender</tt> configured to send messages to
+   * the supplied Kafka brokers.
+   * @param kafkaBrokers list of Kafka brokers, in the form host:port
+   */
   public MetricSender(List<String> kafkaBrokers) {
     kafkaTemplate = KafkaConfig.createKafkaTemplate(kafkaBrokers);
   }
 
+  /**
+   * Sends a <tt>Metric</tt> message to the specified topic
+   * @param topic topic to which to send messages
+   * @param metric data to send
+   */
   public void send(String topic, Metric metric) {
     kafkaTemplate.send(topic, metric);
   }
 
+  /**
+   * Sends a <tt>Metric</tt> message to the specified topic with a given key.
+   * @param topic topic to which to send messages
+   * @param key key for the message
+   * @param metric data to send
+   */
   public void send(String topic, String key, Metric metric) {
     kafkaTemplate.send(topic, key, metric);
   }
 
+  /**
+   * Flushes the producer send buffer.
+   */
   public void flush() {
     kafkaTemplate.flush();
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSender.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSender.java
@@ -1,0 +1,27 @@
+package edu.marist.mscs710.metricscollector.kafka;
+
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.List;
+
+public class MetricSender {
+
+  private KafkaTemplate<String, Metric> kafkaTemplate;
+
+  public MetricSender(List<String> kafkaBrokers) {
+    kafkaTemplate = KafkaConfig.createKafkaTemplate(kafkaBrokers);
+  }
+
+  public void send(String topic, Metric metric) {
+    kafkaTemplate.send(topic, metric);
+  }
+
+  public void send(String topic, String key, Metric metric) {
+    kafkaTemplate.send(topic, key, metric);
+  }
+
+  public void flush() {
+    kafkaTemplate.flush();
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSerializer.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSerializer.java
@@ -1,0 +1,18 @@
+package edu.marist.mscs710.metricscollector.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class MetricSerializer implements Serializer<Metric> {
+
+  @Override
+  public byte[] serialize(String s, Metric metric) {
+    try {
+      return new ObjectMapper().writeValueAsBytes(metric);
+    } catch (JsonProcessingException ex) {
+      return new byte[0];
+    }
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSerializer.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/kafka/MetricSerializer.java
@@ -3,15 +3,24 @@ package edu.marist.mscs710.metricscollector.kafka;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.utils.LoggerUtils;
 import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Class to serialize <tt>Metric</tt> objects to Kafka.
+ */
 public class MetricSerializer implements Serializer<Metric> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetricSerializer.class);
+  private ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
   public byte[] serialize(String s, Metric metric) {
     try {
-      return new ObjectMapper().writeValueAsBytes(metric);
+      return objectMapper.writeValueAsBytes(metric);
     } catch (JsonProcessingException ex) {
+      LOGGER.error(LoggerUtils.getExceptionMessage(ex));
       return new byte[0];
     }
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Fields.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Fields.java
@@ -1,0 +1,54 @@
+package edu.marist.mscs710.metricscollector.metric;
+
+public class Fields {
+
+  public enum Cpu {
+    DATETIME, // Unix Time in millis
+    TEMPERATURE, // Celsius
+    UTILIZATION // Pct utilization since last update
+  }
+
+  public enum CpuCore {
+    DATETIME, // Unix Time in millis
+    CORE_ID,
+    CORE_UTILIZATION, // Pct utilization since last update
+  }
+
+  public enum Memory {
+    DATETIME, // Unix Time in millis
+    UTILIZATION, // Pct of memory in use
+    PAGE_FAULTS // Page faults / sec since last update
+  }
+
+  public enum Network {
+    DATETIME, // Unix Time in millis
+    THROUGHPUT, // kb / s network capacity, sum over active networks since last update
+    SEND, // kb / s sent since last update
+    RECEIVE // kb / s received since last update
+  }
+
+  public enum Processes {
+    DATETIME, // Unix Time in millis
+    PID,
+    NAME,
+    START_TIME, // Unix Time in millis
+    UPTIME, // Millis
+    CPU_USAGE, // Pct utilization since last update
+    MEMORY, // Total KB allocated to process and in RAM
+    KB_READ, // KB read from disk per second since last update
+    KB_WRITTEN, // KB written to disk per second since last update
+    STATE // Process State
+  }
+
+  public enum SystemMetrics {
+    DATETIME, // Unix Time in millis
+    UPTIME // Seconds since boot time
+  }
+
+  public enum SystemConstants {
+    TOTAL_MEMORY, // GB
+    PHYSICAL_CORES,
+    LOGICAL_CORES,
+    CPU_SPEED // GHz
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Fields.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Fields.java
@@ -1,59 +1,188 @@
 package edu.marist.mscs710.metricscollector.metric;
 
+/**
+ * Specifies fields for the <tt>metricData</tt> associated with a
+ * <tt>Metric</tt> object.
+ */
 public class Fields {
 
+  /**
+   * <tt>MetricType.CPU</tt> fields
+   */
   public enum Cpu {
-    DATETIME, // Unix Time in millis
+    /**
+     * Epoch milli timestamp of this snapshot of metric data
+     */
+    DATETIME,
+    /**
+     * Time covered by this snapshot
+     */
     DELTA_MILLIS,
-    TEMPERATURE, // Celsius
-    UTILIZATION // Pct utilization since last update
+    /**
+     * CPU temperature in degrees Celsius, 0.0 if not available
+     */
+    TEMPERATURE,
+    /**
+     * CPU utilization during this snapshot from 0.0-1.0
+     */
+    UTILIZATION
   }
 
+  /**
+   * <tt>MetricType.CPU_CORE</tt> fields
+   */
   public enum CpuCore {
-    DATETIME, // Unix Time in millis
+    /**
+     * Epoch milli timestamp of this snapshot of metric data
+     */
+    DATETIME,
+    /**
+     * Time covered by this snapshot
+     */
     DELTA_MILLIS,
+    /**
+     * The CPU core id
+     */
     CORE_ID,
-    CORE_UTILIZATION, // Pct utilization since last update
+    /**
+     * The CPU core utilization during this snapshot, from 0.0-1.0
+     */
+    CORE_UTILIZATION,
   }
 
+  /**
+   * <tt>MetricType.MEMORY</tt> fields
+   */
   public enum Memory {
-    DATETIME, // Unix Time in millis
+    /**
+     * Epoch milli timestamp of this snapshot of metric data
+     */
+    DATETIME,
+    /**
+     * Time covered by this snapshot
+     */
     DELTA_MILLIS,
-    UTILIZATION, // Pct of memory in use
-    PAGE_FAULTS // Page faults / sec since last update
+    /**
+     * Memory utilization from 0.0-1.0
+     */
+    UTILIZATION,
+    /**
+     * Number of page faults per second during this snapshot
+     */
+    PAGE_FAULTS
   }
 
+  /**
+   * <tt>MetricType.NETWORK</tt> fields
+   */
   public enum Network {
-    DATETIME, // Unix Time in millis
+    /**
+     * Epoch milli timestamp of this snapshot of metric data
+     */
+    DATETIME,
+    /**
+     * Time covered by this snapshot
+     */
     DELTA_MILLIS,
-    THROUGHPUT, // kb / s network capacity, sum over active networks since last update
-    SEND, // kb / s sent since last update
-    RECEIVE // kb / s received since last update
+    /**
+     * Kilobits per second network capacity, the sum over active networks during
+     * this snapshot. A network interface is considered inactive after five
+     * minutes of inactivity.
+     */
+    THROUGHPUT,
+    /**
+     * Kilobits per second sent during this snapshot
+     */
+    SEND,
+    /**
+     * Kilobits per second received during this snapshot
+     */
+    RECEIVE
   }
 
+  /**
+   * <tt>MetricType.PROCESSES</tt> fields
+   */
   public enum Processes {
-    DATETIME, // Unix Time in millis
+    /**
+     * Epoch milli timestamp of this snapshot of metric data
+     */
+    DATETIME,
+    /**
+     * Time covered by this snapshot
+     */
     DELTA_MILLIS,
+    /**
+     * Process id
+     */
     PID,
+    /**
+     * Process name
+     */
     NAME,
-    START_TIME, // Unix Time in millis
-    UPTIME, // Millis
-    CPU_USAGE, // Pct utilization since last update
-    MEMORY, // Total KB allocated to process and in RAM
-    KB_READ, // KB read from disk per second since last update
-    KB_WRITTEN, // KB written to disk per second since last update
-    STATE // Process State
+    /**
+     * Start time of process as epoch milli timestamp
+     */
+    START_TIME,
+    /**
+     * Time the process has been running in milliseconds
+     */
+    UPTIME,
+    /**
+     * CPU usage of the process during this snapshot
+     */
+    CPU_USAGE,
+    /**
+     * Number of kilobytes of memory allocated to this process and in RAM
+     */
+    MEMORY,
+    /**
+     * Kilobytes per second read from disk during this snapshot
+     */
+    KB_READ,
+    /**
+     * Kilobytes per second written to disk during this snapshot
+     */
+    KB_WRITTEN,
+    /**
+     * Process state
+     */
+    STATE
   }
 
+  /**
+   * <tt>MetricType.SYSTEM_METRICS</tt> fields
+   */
   public enum SystemMetrics {
-    DATETIME, // Unix Time in millis
-    UPTIME // Seconds since boot time
+    /**
+     * Epoch milli timestamp of this snapshot of metric data
+     */
+    DATETIME,
+    /**
+     * Number of seconds since system boot
+     */
+    UPTIME
   }
 
+  /**
+   * <tt>MetricType.SYSTEM_CONSTANTS</tt> fields
+   */
   public enum SystemConstants {
-    TOTAL_MEMORY, // GB
+    /**
+     * Total memory of the system in gigabytes
+     */
+    TOTAL_MEMORY,
+    /**
+     * Number of physical CPU cores of the system
+     */
     PHYSICAL_CORES,
+    /**
+     * Number of logical CPU cores of the system
+     */
     LOGICAL_CORES,
+    /**
+     * Processor speed in GHz
+     */
     CPU_SPEED // GHz
   }
 }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Fields.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Fields.java
@@ -4,24 +4,28 @@ public class Fields {
 
   public enum Cpu {
     DATETIME, // Unix Time in millis
+    DELTA_MILLIS,
     TEMPERATURE, // Celsius
     UTILIZATION // Pct utilization since last update
   }
 
   public enum CpuCore {
     DATETIME, // Unix Time in millis
+    DELTA_MILLIS,
     CORE_ID,
     CORE_UTILIZATION, // Pct utilization since last update
   }
 
   public enum Memory {
     DATETIME, // Unix Time in millis
+    DELTA_MILLIS,
     UTILIZATION, // Pct of memory in use
     PAGE_FAULTS // Page faults / sec since last update
   }
 
   public enum Network {
     DATETIME, // Unix Time in millis
+    DELTA_MILLIS,
     THROUGHPUT, // kb / s network capacity, sum over active networks since last update
     SEND, // kb / s sent since last update
     RECEIVE // kb / s received since last update
@@ -29,6 +33,7 @@ public class Fields {
 
   public enum Processes {
     DATETIME, // Unix Time in millis
+    DELTA_MILLIS,
     PID,
     NAME,
     START_TIME, // Unix Time in millis

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Metric.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Metric.java
@@ -1,0 +1,29 @@
+package edu.marist.mscs710.metricscollector.metric;
+
+import java.util.Map;
+
+public class Metric {
+  private MetricType metricType;
+  private Map<String, Object> metricData;
+
+  public Metric(MetricType metricType, Map<String, Object> metricData) {
+    this.metricType = metricType;
+    this.metricData = metricData;
+  }
+
+  public MetricType getMetricType() {
+    return metricType;
+  }
+
+  public Map<String, Object> getMetricData() {
+    return metricData;
+  }
+
+  @Override
+  public String toString() {
+    return "Metric{" +
+      "metricType=" + metricType +
+      ", metricData=" + metricData +
+      '}';
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Metric.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Metric.java
@@ -5,11 +5,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
+/**
+ * Holds a snapshot of generic metric data.
+ */
 public class Metric {
   private MetricType metricType;
 
   private Map<String, Object> metricData;
 
+  /**
+   * Constructs a new <tt>Metric</tt> with the supplied metrics.
+   * @param metricType type of the metric
+   * @param metricData map of metric data
+   */
   @JsonCreator
   public Metric(@JsonProperty(value = "metricType") MetricType metricType,
                 @JsonProperty(value = "metricData") Map<String, Object> metricData) {
@@ -17,10 +25,18 @@ public class Metric {
     this.metricData = metricData;
   }
 
+  /**
+   * Gets the metric type.
+   * @return metric type
+   */
   public MetricType getMetricType() {
     return metricType;
   }
 
+  /**
+   * Gets the metric data.
+   * @return metric data
+   */
   public Map<String, Object> getMetricData() {
     return metricData;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Metric.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/Metric.java
@@ -1,12 +1,18 @@
 package edu.marist.mscs710.metricscollector.metric;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Map;
 
 public class Metric {
   private MetricType metricType;
+
   private Map<String, Object> metricData;
 
-  public Metric(MetricType metricType, Map<String, Object> metricData) {
+  @JsonCreator
+  public Metric(@JsonProperty(value = "metricType") MetricType metricType,
+                @JsonProperty(value = "metricData") Map<String, Object> metricData) {
     this.metricType = metricType;
     this.metricData = metricData;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/MetricType.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/MetricType.java
@@ -1,0 +1,6 @@
+package edu.marist.mscs710.metricscollector.metric;
+
+public enum MetricType {
+  CPU, CPU_CORE, MEMORY, NETWORK, PROCESSES,
+  GPU, SYSTEM_CONSTANTS, SYSTEM_METRICS
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/MetricType.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/MetricType.java
@@ -2,5 +2,5 @@ package edu.marist.mscs710.metricscollector.metric;
 
 public enum MetricType {
   CPU, CPU_CORE, MEMORY, NETWORK, PROCESSES,
-  GPU, SYSTEM_CONSTANTS, SYSTEM_METRICS
+  GPU, SYSTEM_CONSTANTS, SYSTEM_METRICS, NULL
 }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/MetricType.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/metric/MetricType.java
@@ -1,5 +1,8 @@
 package edu.marist.mscs710.metricscollector.metric;
 
+/**
+ * Types of <tt>Metric</tt> objects
+ */
 public enum MetricType {
   CPU, CPU_CORE, MEMORY, NETWORK, PROCESSES,
   GPU, SYSTEM_CONSTANTS, SYSTEM_METRICS, NULL

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/producer/OSMetricsProducer.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/producer/OSMetricsProducer.java
@@ -1,0 +1,179 @@
+package edu.marist.mscs710.metricscollector.producer;
+
+import edu.marist.mscs710.metricscollector.MetricSource;
+import edu.marist.mscs710.metricscollector.MetricsProducer;
+import edu.marist.mscs710.metricscollector.data.MetricData;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+import edu.marist.mscs710.metricscollector.system.*;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public class OSMetricsProducer implements MetricsProducer {
+  private static final boolean FROM_NOW = true;
+  private static final boolean PLUS_NEXT = false;
+  private static final int MINIMUM_FREQUENCY = 5;
+  private static final int DEFAULT_FREQUENCY = MINIMUM_FREQUENCY;
+
+  private AtomicInteger frequency;
+  private AtomicLong nextProduceTime;
+  private AtomicBoolean running;
+  private AtomicBoolean started;
+
+  private List<MetricSource> metricSources;
+
+
+  public OSMetricsProducer(int frequency) {
+    this.frequency = new AtomicInteger(Math.max(frequency, MINIMUM_FREQUENCY));
+    this.running = new AtomicBoolean(false);
+    this.nextProduceTime = new AtomicLong(-1L);
+    this.started = new AtomicBoolean(false);
+    this.metricSources = new ArrayList<>();
+  }
+
+  public OSMetricsProducer() {
+    this(DEFAULT_FREQUENCY);
+  }
+
+  @Override
+  public boolean start() {
+    if (started.get()) {
+      return false;
+    } else {
+      addAllMetricSources();
+      setNextProduceTime(frequency.get(), FROM_NOW);
+      this.run();
+      started.set(true);
+      return true;
+    }
+  }
+
+  @Override
+  public boolean pause(int seconds) {
+    if (!started.get() || seconds == 0 || nextProduceTime.get() < 0) return false;
+
+    if (seconds > 0)
+      setNextProduceTime(seconds, PLUS_NEXT);
+    else
+      pauseIndefinitely();
+    return true;
+  }
+
+  @Override
+  public boolean wakeup() {
+    if (!started.get() || frequency.get() >= 0) return false;
+
+    setNextProduceTime(frequency.get(), FROM_NOW);
+    return true;
+  }
+
+  @Override
+  public boolean setFrequency(int seconds) {
+    if (seconds < MINIMUM_FREQUENCY) {
+      return false;
+    } else {
+      frequency.set(seconds);
+      return true;
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    running.set(false);
+  }
+
+  @Override
+  public int getFrequency() {
+    return frequency.get();
+  }
+
+  @Override
+  public long getNextProduceTime() {
+    return nextProduceTime.get();
+  }
+
+  @Override
+  public boolean isStarted() {
+    return started.get();
+  }
+
+  private void run() {
+    running.set(true);
+    new Thread(this::produceMetrics).start();
+  }
+
+  private void produceMetrics() {
+    while (running.get()) {
+      long sleepTime;
+      while ((sleepTime = getSleepTime()) > 0) {
+        try {
+          Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+          e.printStackTrace(); // TODO: what should we do here?
+        }
+      }
+
+      setNextProduceTime(frequency.get(), FROM_NOW);
+
+      List<MetricData> metricDataList = metricSources.stream()
+        .map(MetricSource::getMetricData)
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
+
+      for (MetricData metricData : metricDataList) {
+        for (Metric metric : metricData.toMetricRecords())
+          sendToKafka(metric);
+      }
+
+      System.out.println();
+    }
+  }
+
+  private void sendToKafka(Metric metric) {
+    if (metric.getMetricType() != MetricType.PROCESSES) {
+      System.out.println(Instant.now().toEpochMilli());
+      System.out.println(metric.toString());
+      System.out.println();
+    }
+  }
+
+  private long getSleepTime() {
+    long timeRemaining = nextProduceTime.get() - Instant.now().toEpochMilli();
+
+    if (timeRemaining < 15)
+      return 0;
+    else if (timeRemaining < 100)
+      return timeRemaining - 10;
+    else if (timeRemaining < 500)
+      return timeRemaining - 50;
+    else
+      return timeRemaining - 100;
+  }
+
+  private void addAllMetricSources() {
+    if (!started.get()) {
+      metricSources.add(new Cpu(true));
+      metricSources.add(new Memory());
+      metricSources.add(new Network());
+      metricSources.add(new SystemMetrics());
+      metricSources.add(new Processes());
+    }
+  }
+
+  private void setNextProduceTime(int seconds, boolean fromNow) {
+    if (fromNow)
+      nextProduceTime.set(Instant.now().plusSeconds(seconds).toEpochMilli());
+    else
+      nextProduceTime.set(Instant.ofEpochMilli(nextProduceTime.get()).plusSeconds(seconds).toEpochMilli());
+  }
+
+  private void pauseIndefinitely() {
+    nextProduceTime.set(-1L);
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Cpu.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Cpu.java
@@ -1,0 +1,90 @@
+package edu.marist.mscs710.metricscollector.system;
+
+import edu.marist.mscs710.metricscollector.MetricSource;
+import edu.marist.mscs710.metricscollector.data.CpuData;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.Sensors;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalDouble;
+
+public class Cpu implements MetricSource {
+  private static final double ONE_GHZ = 1000000000.0;
+  private CentralProcessor processor;
+  private Sensors sensors;
+  private long[][] prevProcTicks;
+  private final boolean reportPhysicalCores;
+  private final double cpuSpeed;
+  private long lastCheckInMillis;
+
+  public Cpu(boolean reportPhysicalCores) {
+    HardwareAbstractionLayer hardware = new SystemInfo().getHardware();
+    this.processor = hardware.getProcessor();
+    this.sensors = hardware.getSensors();
+
+    int numPhysCores = processor.getPhysicalProcessorCount();
+    int numLogCores = processor.getLogicalProcessorCount();
+    this.reportPhysicalCores = numPhysCores * 2 == numLogCores && reportPhysicalCores;
+
+    long freq = processor.getProcessorIdentifier().getVendorFreq();
+    this.cpuSpeed = Math.round(freq * 100.0 / ONE_GHZ) / 100.0;
+
+    this.prevProcTicks = processor.getProcessorCpuLoadTicks();
+    this.lastCheckInMillis = Instant.now().toEpochMilli();
+  }
+
+  @Override
+  public List<CpuData> getMetricData() {
+    double[] cpuCoreUsages = getCpuCoreUsageSinceLastCheck();
+
+    long curMillis = Instant.now().toEpochMilli();
+    long deltaMillis = curMillis - lastCheckInMillis;
+    lastCheckInMillis = curMillis;
+
+    return Collections.singletonList(
+      new CpuData(cpuCoreUsages, getTotalCpuUsage(cpuCoreUsages),
+        getCpuTemp(), deltaMillis, curMillis)
+    );
+  }
+
+  private double[] getCpuCoreUsageSinceLastCheck() {
+    long[][] currentProcTicks = processor.getProcessorCpuLoadTicks();
+    double[] logCoreUsages = processor.getProcessorCpuLoadBetweenTicks(prevProcTicks);
+    prevProcTicks = currentProcTicks;
+
+    // CPU % per core as double[] 0.0-1.0
+    return reportPhysicalCores ? reduceToPhysicalCores(logCoreUsages) : logCoreUsages;
+  }
+
+  public static double getTotalCpuUsage(double[] perCoreUsages) {
+    OptionalDouble avg = Arrays.stream(perCoreUsages).average();
+    return avg.isPresent() ? avg.getAsDouble() : Double.NaN; // 0.0-1.0
+  }
+
+  public double getCpuTemp() {
+    return sensors.getCpuTemperature(); // CPU temp in Celsius
+  }
+
+  public double getCpuSpeed() {
+    return cpuSpeed; // GHz
+  }
+
+  private double[] reduceToPhysicalCores(double[] logCoreUsages) {
+    int numLogCores = logCoreUsages.length;
+
+    if (numLogCores % 2 != 0)
+      return logCoreUsages;
+
+    double[] physCoreUsages = new double[numLogCores / 2];
+    for (int i = 0; i < physCoreUsages.length; i++) {
+      physCoreUsages[i] = (logCoreUsages[i * 2] + logCoreUsages[i * 2 + 1]) / 2;
+    }
+
+    return physCoreUsages;
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Cpu.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Cpu.java
@@ -13,6 +13,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.OptionalDouble;
 
+/**
+ * Represents a CPU of an operating system. Produces metrics on demand, keeping
+ * the previous state of the CPU.
+ */
 public class Cpu implements MetricSource {
   private static final double ONE_GHZ = 1000000000.0;
   private CentralProcessor processor;
@@ -22,6 +26,13 @@ public class Cpu implements MetricSource {
   private final double cpuSpeed;
   private long lastCheckInMillis;
 
+  /**
+   * Constructs a new <tt>Cpu</tt>.
+   * @param reportPhysicalCores attempts to reduce CPU core usage metrics
+   *                            to physical cores rather than logical cores. If
+   *                            logical cores = physical cores * 2, passing <tt>true</tt>
+   *                            will produce per physical core metrics
+   */
   public Cpu(boolean reportPhysicalCores) {
     HardwareAbstractionLayer hardware = new SystemInfo().getHardware();
     this.processor = hardware.getProcessor();
@@ -61,15 +72,28 @@ public class Cpu implements MetricSource {
     return reportPhysicalCores ? reduceToPhysicalCores(logCoreUsages) : logCoreUsages;
   }
 
+  /**
+   * Static method to reduce per core usage data to total CPU usage.
+   * @param perCoreUsages array of CPU core usages
+   * @return total CPU usage
+   */
   public static double getTotalCpuUsage(double[] perCoreUsages) {
     OptionalDouble avg = Arrays.stream(perCoreUsages).average();
     return avg.isPresent() ? avg.getAsDouble() : Double.NaN; // 0.0-1.0
   }
 
+  /**
+   * Gets the CPU temperature in degrees Celsius, or 0.0 if unavailable.
+   * @return CPU temperature
+   */
   public double getCpuTemp() {
     return sensors.getCpuTemperature(); // CPU temp in Celsius
   }
 
+  /**
+   * Gets the speed in GHz of the processor.
+   * @return processor speed
+   */
   public double getCpuSpeed() {
     return cpuSpeed; // GHz
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Memory.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Memory.java
@@ -10,6 +10,10 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Represents the memory unit of an operating system. Produces metrics on demand,
+ * keeping the previous state of the memory.
+ */
 public class Memory implements MetricSource {
   private static final double ONE_GB = 1073741824.0;
   private GlobalMemory mem;
@@ -19,6 +23,9 @@ public class Memory implements MetricSource {
   private long lastSwapPagesIn;
   private long lastCheckInMillis;
 
+  /**
+   * Constructs a new <tt>Memory</tt>
+   */
   public Memory() {
     this.mem = new SystemInfo().getHardware().getMemory();
     this.vMem = mem.getVirtualMemory();
@@ -41,6 +48,10 @@ public class Memory implements MetricSource {
     );
   }
 
+  /**
+   * Gets the percent memory utilization, from 0.0-1.0
+   * @return memory utilization
+   */
   public double getMemoryUtilization() {
     return 1.0 - (double) mem.getAvailable() / totalMemBytes; // 0.0-1.0
   }
@@ -52,10 +63,18 @@ public class Memory implements MetricSource {
     return pageFaults;
   }
 
+  /**
+   * Gets the total memory of the system in bytes.
+   * @return total memory
+   */
   public long getTotalMemoryInBytes() {
     return totalMemBytes;
   }
 
+  /**
+   * Gets the total memory of the system in GB.
+   * @return total memory
+   */
   public double getTotalMemoryInGb() {
     return totalMemGb;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Memory.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Memory.java
@@ -1,0 +1,62 @@
+package edu.marist.mscs710.metricscollector.system;
+
+import edu.marist.mscs710.metricscollector.MetricSource;
+import edu.marist.mscs710.metricscollector.data.MemoryData;
+import oshi.SystemInfo;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.VirtualMemory;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+public class Memory implements MetricSource {
+  private static final double ONE_GB = 1073741824.0;
+  private GlobalMemory mem;
+  private VirtualMemory vMem;
+  private final long totalMemBytes;
+  private final double totalMemGb;
+  private long lastSwapPagesIn;
+  private long lastCheckInMillis;
+
+  public Memory() {
+    this.mem = new SystemInfo().getHardware().getMemory();
+    this.vMem = mem.getVirtualMemory();
+    this.totalMemBytes = mem.getTotal();
+    this.totalMemGb = Math.round(10.0 * totalMemBytes / ONE_GB) / 10.0;
+    this.lastSwapPagesIn = vMem.getSwapPagesIn();
+    this.lastCheckInMillis = Instant.now().toEpochMilli();
+  }
+
+  @Override
+  public List<MemoryData> getMetricData() {
+    long pageFaults = getPageFaultsSinceLastCheck();
+
+    long curMillis = Instant.now().toEpochMilli();
+    long deltaMillis = curMillis - lastCheckInMillis;
+    lastCheckInMillis = curMillis;
+
+    return Collections.singletonList(
+      new MemoryData(getMemoryUtilization(), pageFaults, deltaMillis, curMillis)
+    );
+  }
+
+  public double getMemoryUtilization() {
+    return 1.0 - (double) mem.getAvailable() / totalMemBytes; // 0.0-1.0
+  }
+
+  private long getPageFaultsSinceLastCheck() {
+    long currentSwapPagesIn = vMem.getSwapPagesIn();
+    long pageFaults = currentSwapPagesIn - lastSwapPagesIn;
+    lastSwapPagesIn = currentSwapPagesIn;
+    return pageFaults;
+  }
+
+  public long getTotalMemoryInBytes() {
+    return totalMemBytes;
+  }
+
+  public double getTotalMemoryInGb() {
+    return totalMemGb;
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Network.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Network.java
@@ -1,0 +1,86 @@
+package edu.marist.mscs710.metricscollector.system;
+
+import edu.marist.mscs710.metricscollector.MetricSource;
+import edu.marist.mscs710.metricscollector.data.NetworkData;
+import oshi.SystemInfo;
+import oshi.hardware.NetworkIF;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+public class Network implements MetricSource {
+  private static final int FIVE_MINUTES_IN_MILLIS = 300000;
+  private NetworkIF[] networks;
+  private LastNetworkValues[] lastValues;
+  private long lastCheckInMillis;
+
+  public Network() {
+    this.networks = new SystemInfo().getHardware().getNetworkIFs();
+    lastCheckInMillis = Instant.now().toEpochMilli();
+    this.lastValues = new LastNetworkValues[networks.length];
+
+    for (int i = 0; i < networks.length; i++) {
+      lastValues[i] = new LastNetworkValues();
+      lastValues[i].bytesSent = networks[i].getBytesSent();
+      lastValues[i].bytesRecv = networks[i].getBytesRecv();
+      lastValues[i].millisIdle = 0;
+    }
+  }
+
+  @Override
+  public List<NetworkData> getMetricData() {
+    long deltaBytesSent = 0;
+    long deltaBytesRecv = 0;
+    long totalActiveSpeed = 0;
+
+    updateNetworkIFs();
+
+    long curMillis = Instant.now().toEpochMilli();
+    long deltaMillis = curMillis - lastCheckInMillis;
+    lastCheckInMillis = curMillis;
+
+    for (int i = 0; i < networks.length; i++) {
+      if (lastValues[i].millisIdle < FIVE_MINUTES_IN_MILLIS) {
+        if (networks[i].getBytesSent() != 0 || networks[i].getBytesRecv() != 0) {
+          deltaBytesSent += networks[i].getBytesSent() - lastValues[i].bytesSent;
+          deltaBytesRecv += networks[i].getBytesRecv() - lastValues[i].bytesRecv;
+          totalActiveSpeed += networks[i].getSpeed();
+        }
+      }
+    }
+
+    updateLastValues(deltaMillis);
+
+    return Collections.singletonList(
+      new NetworkData(deltaBytesSent, deltaBytesRecv, totalActiveSpeed, deltaMillis, curMillis)
+    );
+  }
+
+  private void updateNetworkIFs() {
+    for (NetworkIF network : networks) {
+      network.updateAttributes();
+    }
+  }
+
+  private void updateLastValues(long deltaMillis) {
+    for (int i = 0; i < networks.length; i++) {
+      long curBytesSent = networks[i].getBytesSent();
+      long curBytesRecv = networks[i].getBytesRecv();
+
+      if (curBytesSent == lastValues[i].bytesSent && curBytesRecv == lastValues[i].bytesRecv) {
+        lastValues[i].millisIdle += deltaMillis;
+      } else {
+        lastValues[i].millisIdle = 0;
+        lastValues[i].bytesSent = curBytesSent;
+        lastValues[i].bytesRecv = curBytesRecv;
+      }
+    }
+  }
+
+  private static class LastNetworkValues {
+    long bytesSent;
+    long bytesRecv;
+    long millisIdle;
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Network.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Network.java
@@ -9,12 +9,19 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Represents the network interfaces of a system. Produces metrics on demand,
+ * keeping the previous state of the interfaces.
+ */
 public class Network implements MetricSource {
   private static final int FIVE_MINUTES_IN_MILLIS = 300000;
   private NetworkIF[] networks;
   private LastNetworkValues[] lastValues;
   private long lastCheckInMillis;
 
+  /**
+   * Constructs a new <tt>Network</tt>
+   */
   public Network() {
     this.networks = new SystemInfo().getHardware().getNetworkIFs();
     lastCheckInMillis = Instant.now().toEpochMilli();

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Processes.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Processes.java
@@ -1,7 +1,6 @@
 package edu.marist.mscs710.metricscollector.system;
 
 import edu.marist.mscs710.metricscollector.MetricSource;
-import edu.marist.mscs710.metricscollector.data.MetricData;
 import edu.marist.mscs710.metricscollector.data.ProcessData;
 import oshi.SystemInfo;
 import oshi.software.os.OSProcess;
@@ -12,18 +11,43 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * Represents the processes running on an operating system. Produces metrics
+ * on demand, keeping the previous state of the processes.
+ */
 public class Processes implements MetricSource {
   private final int numLogicalCores;
   private OperatingSystem os;
   private Map<Integer, OSProcess> priorProcSnapshots;
 
+  /**
+   * State of a process
+   */
   public enum PidState {
-    NEW, // Pid is new since last update
-    RUNNING, // Pid is same process as last update
-    RECYCLED, // Pid is a new process with the same pid as one in the last update
-    ENDED // Pid has ended since the last update
+    /**
+     * A process that has started since the last state update
+     */
+    NEW,
+    /**
+     * A process that was running during the last state update, and is
+     * currently running
+     */
+    RUNNING,
+    /**
+     * A process that has started since the last state update, but has the
+     * same process ID as a process that was seen during the last state update
+     */
+    RECYCLED,
+    /**
+     * A process that was running during the last state update, but has ended
+     * since then
+     */
+    ENDED
   }
 
+  /**
+   * Constructs a new <tt>Processes</tt>
+   */
   public Processes() {
     SystemInfo sys = new SystemInfo();
     numLogicalCores = sys.getHardware().getProcessor().getLogicalProcessorCount();

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Processes.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/Processes.java
@@ -1,0 +1,150 @@
+package edu.marist.mscs710.metricscollector.system;
+
+import edu.marist.mscs710.metricscollector.MetricSource;
+import edu.marist.mscs710.metricscollector.data.MetricData;
+import edu.marist.mscs710.metricscollector.data.ProcessData;
+import oshi.SystemInfo;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class Processes implements MetricSource {
+  private final int numLogicalCores;
+  private OperatingSystem os;
+  private Map<Integer, OSProcess> priorProcSnapshots;
+
+  public enum PidState {
+    NEW, // Pid is new since last update
+    RUNNING, // Pid is same process as last update
+    RECYCLED, // Pid is a new process with the same pid as one in the last update
+    ENDED // Pid has ended since the last update
+  }
+
+  public Processes() {
+    SystemInfo sys = new SystemInfo();
+    numLogicalCores = sys.getHardware().getProcessor().getLogicalProcessorCount();
+    os = sys.getOperatingSystem();
+
+    updateProcessSnapshots(getCurrentProcesses());
+  }
+
+  @Override
+  public List<ProcessData> getMetricData() {
+    List<OSProcess> osProcesses = getCurrentProcesses();
+    List<ProcessData> dataList = new ArrayList<>(osProcesses.size());
+
+    for (OSProcess p : osProcesses) {
+      ProcessData pData = createProcessDataAndDeleteFromCache(p);
+
+      if (pData != null)
+        dataList.add(pData);
+    }
+
+    for (OSProcess endedProc : priorProcSnapshots.values()) {
+      dataList.add(new ProcessData(endedProc.getProcessID(),
+                                   endedProc.getName(),
+                                   Instant.now().toEpochMilli()));
+    }
+
+    updateProcessSnapshots(osProcesses);
+
+    return dataList;
+  }
+
+  private ProcessData createProcessDataAndDeleteFromCache(OSProcess p) {
+    if (p == null) return null;
+
+    int pid = p.getProcessID();
+    OSProcess prior = priorProcSnapshots.remove(pid);
+
+    if (prior != null) { // Recycled pid or already-running process
+      boolean recycled = isRecycledPid(prior, p);
+
+      if (!recycled)
+        p.setStartTime(prior.getStartTime()); // start time has +- 1 ms error between process updates, so update
+                                            // this to always return original start time, this is RUNNING case
+      return new ProcessData(
+        pid,
+        p.getName(),
+        p.getStartTime(), // If not recycled, we have updated start time above, else start time of new (recycled) process
+        p.getUpTime(),
+        getProcessCpuLoadBetweenChecks(prior, p) / numLogicalCores,
+        p.getResidentSetSize(),
+        recycled ? p.getBytesRead() : p.getBytesRead() - prior.getBytesRead(),
+        recycled ? p.getBytesWritten() : p.getBytesWritten() - prior.getBytesWritten(),
+        recycled ? PidState.RECYCLED : PidState.RUNNING,
+        recycled ? p.getUpTime() : p.getUpTime() - prior.getUpTime(),
+        p.getStartTime() + p.getUpTime()
+      );
+    } else { // New process
+      return new ProcessData(pid,
+        p.getName(),
+        p.getStartTime(),
+        p.getUpTime(),
+        getTotalCpuLoad(p) / numLogicalCores,
+        p.getResidentSetSize(),
+        p.getBytesRead(),
+        p.getBytesWritten(),
+        PidState.NEW,
+        p.getUpTime(),
+        p.getStartTime() + p.getUpTime()
+      );
+    }
+  }
+
+  private static boolean isRecycledPid(OSProcess prior, OSProcess p) {
+    return prior != null
+      && p != null
+      && prior.getProcessID() == p.getProcessID()
+      && p.getStartTime() > prior.getStartTime() + 5;
+  }
+
+  private static double getProcessCpuLoadBetweenChecks(OSProcess prior, OSProcess p) {
+    if (isRecycledPid(prior, p)) {
+      return getTotalCpuLoad(p);
+    } else {
+      return (p.getUserTime() - prior.getUserTime() + p.getKernelTime() - prior.getKernelTime())
+              / (double) (p.getUpTime() - prior.getUpTime());
+    }
+  }
+
+  private static double getTotalCpuLoad(OSProcess p) {
+    return p == null ? -1 : (p.getKernelTime() + p.getUserTime()) / (double) p.getUpTime();
+  }
+
+  private List<OSProcess> getCurrentProcesses() {
+    OSProcess[] osProcesses = os.getProcesses();
+    if (osProcesses == null) return new ArrayList<>();
+
+    List<Integer> pids = new ArrayList<>(osProcesses.length);
+
+    for (OSProcess p : osProcesses) {
+      if (p != null)
+        pids.add(p.getProcessID());
+    }
+
+    List<OSProcess> processList = os.getProcesses(pids);
+    while (processList.size() < pids.size()) {
+      pids.clear();
+
+      for (OSProcess p : processList) {
+        if (p != null)
+          pids.add(p.getProcessID());
+      }
+
+      processList = os.getProcesses(pids);
+    }
+
+    return processList;
+  }
+
+  private void updateProcessSnapshots(List<OSProcess> processes) {
+    priorProcSnapshots = processes.stream()
+      .filter(Objects::nonNull)
+      .collect(Collectors.toMap(OSProcess::getProcessID, Function.identity()));
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemConstants.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemConstants.java
@@ -1,0 +1,69 @@
+package edu.marist.mscs710.metricscollector.system;
+
+import edu.marist.mscs710.metricscollector.MetricRecord;
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SystemConstants implements MetricRecord {
+  private static long totalMemBytes;
+  private static double totalMemGb;
+  private static int physicalCores;
+  private static int logicalCores;
+  private static double cpuSpeed; // GHz
+
+  public SystemConstants() {
+    Memory mem = new Memory();
+    totalMemBytes = mem.getTotalMemoryInBytes();
+    totalMemGb = mem.getTotalMemoryInGb();
+
+    cpuSpeed = new Cpu(true).getCpuSpeed();
+
+    CentralProcessor processor = new SystemInfo().getHardware().getProcessor();
+    physicalCores = processor.getPhysicalProcessorCount();
+    logicalCores = processor.getLogicalProcessorCount();
+  }
+
+  public static long getTotalMemBytes() {
+    return totalMemBytes;
+  }
+
+  public static double getTotalMemGb() {
+    return totalMemGb;
+  }
+
+  public static int getPhysicalCores() {
+    return physicalCores;
+  }
+
+  public static int getLogicalCores() {
+    return logicalCores;
+  }
+
+  public static double getCpuSpeed() {
+    return cpuSpeed;
+  }
+
+  private Map<String, Object> getSystemConstantMap() {
+    return new HashMap<String, Object>() {
+      {
+        put(Fields.SystemConstants.CPU_SPEED.toString(), cpuSpeed);
+        put(Fields.SystemConstants.LOGICAL_CORES.toString(), logicalCores);
+        put(Fields.SystemConstants.PHYSICAL_CORES.toString(), physicalCores);
+        put(Fields.SystemConstants.TOTAL_MEMORY.toString(), totalMemGb);
+      }
+    };
+  }
+
+  @Override
+  public List<Metric> toMetricRecords() {
+    return Collections.singletonList(new Metric(MetricType.SYSTEM_CONSTANTS, getSystemConstantMap()));
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemConstants.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemConstants.java
@@ -12,13 +12,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Class to hold the constant values for a particular system.
+ */
 public class SystemConstants implements MetricRecord {
   private static long totalMemBytes;
   private static double totalMemGb;
   private static int physicalCores;
   private static int logicalCores;
-  private static double cpuSpeed; // GHz
+  private static double cpuSpeed;
 
+  /**
+   * Constructs a new <tt>SystemConstants</tt>
+   */
   public SystemConstants() {
     Memory mem = new Memory();
     totalMemBytes = mem.getTotalMemoryInBytes();
@@ -31,22 +37,42 @@ public class SystemConstants implements MetricRecord {
     logicalCores = processor.getLogicalProcessorCount();
   }
 
+  /**
+   * Gets the total memory of the system, in bytes.
+   * @return total memory
+   */
   public static long getTotalMemBytes() {
     return totalMemBytes;
   }
 
+  /**
+   * Gets the total memory of the system, in gigabytes.
+   * @return total memory
+   */
   public static double getTotalMemGb() {
     return totalMemGb;
   }
 
+  /**
+   * Gets the number of physical cores of the system.
+   * @return number of physical cores
+   */
   public static int getPhysicalCores() {
     return physicalCores;
   }
 
+  /**
+   * Gets the number of logical cores of the system.
+   * @return number of logical cores
+   */
   public static int getLogicalCores() {
     return logicalCores;
   }
 
+  /**
+   * Gets the processor speed in GHz.
+   * @return processor speed
+   */
   public static double getCpuSpeed() {
     return cpuSpeed;
   }

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemMetrics.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemMetrics.java
@@ -9,10 +9,16 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Represents overall system metrics.
+ */
 public class SystemMetrics implements MetricSource {
   private OperatingSystem os;
   private long lastCheckInMillis;
 
+  /**
+   * Constructs a new <tt>SystemMetrics</tt>
+   */
   public SystemMetrics() {
     os = new SystemInfo().getOperatingSystem();
     lastCheckInMillis = Instant.now().toEpochMilli();

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemMetrics.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/system/SystemMetrics.java
@@ -1,0 +1,35 @@
+package edu.marist.mscs710.metricscollector.system;
+
+import edu.marist.mscs710.metricscollector.MetricSource;
+import edu.marist.mscs710.metricscollector.data.SystemData;
+import oshi.SystemInfo;
+import oshi.software.os.OperatingSystem;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+public class SystemMetrics implements MetricSource {
+  private OperatingSystem os;
+  private long lastCheckInMillis;
+
+  public SystemMetrics() {
+    os = new SystemInfo().getOperatingSystem();
+    lastCheckInMillis = Instant.now().toEpochMilli();
+  }
+
+  @Override
+  public List<SystemData> getMetricData() {
+    long curMillis = Instant.now().toEpochMilli();
+    long deltaMillis = curMillis - lastCheckInMillis;
+    lastCheckInMillis = curMillis;
+
+    return Collections.singletonList(
+      new SystemData(getUpTime(), deltaMillis, curMillis)
+    );
+  }
+
+  private long getUpTime() {
+    return os.getSystemUptime();
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/utils/LoggerUtils.java
+++ b/resource-monitor/metrics-collector/src/main/java/edu/marist/mscs710/metricscollector/utils/LoggerUtils.java
@@ -1,0 +1,10 @@
+package edu.marist.mscs710.metricscollector.utils;
+
+import java.util.Arrays;
+
+public class LoggerUtils {
+
+  public static String getExceptionMessage(Exception ex) {
+    return ex.getMessage() + System.lineSeparator() + Arrays.toString(ex.getStackTrace());
+  }
+}

--- a/resource-monitor/metrics-collector/src/main/resources/log4j.properties
+++ b/resource-monitor/metrics-collector/src/main/resources/log4j.properties
@@ -1,0 +1,15 @@
+log4j.rootLogger=INFO, stdout, fileAppender
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%date %-5level [%thread] %logger{10} - %msg%n
+
+log4j.appender.fileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.fileAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.fileAppender.File=logs/collector.log
+log4j.appender.fileAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.fileAppender.layout.ConversionPattern=%d %-5p [%t] %c - %m%n
+log4j.appender.fileAppender.append=true
+log4j.appender.fileAppender.MaxBackupIndex=7
+log4j.appender.fileAppender.rollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.fileAppender.rollingPolicy.FileNamePattern=logs/collector.%d.log.zip

--- a/resource-monitor/metrics-collector/src/main/resources/log4j.properties
+++ b/resource-monitor/metrics-collector/src/main/resources/log4j.properties
@@ -1,15 +1,22 @@
-log4j.rootLogger=INFO, stdout, fileAppender
+log4j.rootLogger=INFO, stdout, rootFileAppender
+
+log4j.logger.edu.marist.mscs710=INFO, stdout, collectorAppender
+log4j.additivity.edu.marist.mscs710=false
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%date %-5level [%thread] %logger{10} - %msg%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %-5p [%t] %c{1.} - %m%n
 
-log4j.appender.fileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.collectorAppender=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.fileAppender.DatePattern='.'yyyy-MM-dd-HH
-log4j.appender.fileAppender.File=logs/collector.log
-log4j.appender.fileAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.fileAppender.layout.ConversionPattern=%d %-5p [%t] %c - %m%n
-log4j.appender.fileAppender.append=true
-log4j.appender.fileAppender.MaxBackupIndex=7
-log4j.appender.fileAppender.rollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.fileAppender.rollingPolicy.FileNamePattern=logs/collector.%d.log.zip
+log4j.appender.collectorAppender.File=logs/collector.log
+log4j.appender.collectorAppender.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.collectorAppender.layout.ConversionPattern=%d %-5p [%t] %c{1.} - %m%n
+log4j.appender.collectorAppender.append=true
+
+log4j.appender.rootFileAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.rootFileAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.rootFileAppender.File=logs/infrastructure.log
+log4j.appender.rootFileAppender.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.rootFileAppender.layout.ConversionPattern=%d %-5p [%t] %c{1.} - %m%n
+log4j.appender.rootFileAppender.append=true

--- a/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/KafkaTest.java
+++ b/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/KafkaTest.java
@@ -1,13 +1,21 @@
 package edu.marist.mscs710.metricscollector;
 
+import com.salesforce.kafka.test.KafkaTestUtils;
 import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
 import edu.marist.mscs710.metricscollector.kafka.KafkaConfig;
+import edu.marist.mscs710.metricscollector.kafka.MetricDeserializer;
+import edu.marist.mscs710.metricscollector.kafka.MetricSerializer;
 import edu.marist.mscs710.metricscollector.metric.Fields;
 import edu.marist.mscs710.metricscollector.metric.Metric;
 import edu.marist.mscs710.metricscollector.metric.MetricType;
 import edu.marist.mscs710.metricscollector.producer.OSMetricsProducer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
@@ -22,11 +30,52 @@ public class KafkaTest {
   @ClassRule
   public static final SharedKafkaTestResource kafka = new SharedKafkaTestResource();
 
-  @Test
-  public void testSerializeDeserialize() throws InterruptedException {
-    String kafkaBroker = kafka.getKafkaConnectString();
+  private String topic;
 
-    String topic = "test-topic-embedded";
+  @Before
+  public void generateRandomTopic() {
+    topic = "test-topic-embedded" + Instant.now().toEpochMilli();
+  }
+
+  @Test
+  public void testMetricSerializerDeserializerViaKafka() {
+    Metric before = new Metric(MetricType.SYSTEM_METRICS, new HashMap<String, Object>(){{
+      put(Fields.SystemMetrics.UPTIME.toString(), 999999);
+      put(Fields.SystemMetrics.DATETIME.toString(), 111111);
+    }});
+
+    KafkaTestUtils k = kafka.getKafkaTestUtils();
+
+    try (KafkaProducer<String, Metric> kafkaProducer =
+           k.getKafkaProducer(StringSerializer.class, MetricSerializer.class)) {
+
+      kafkaProducer.send(new ProducerRecord<>(topic, "", before));
+      kafkaProducer.flush();
+    }
+
+    List<ConsumerRecord<String, Metric>> consumerRecords =
+      k.consumeAllRecordsFromTopic(topic, StringDeserializer.class, MetricDeserializer.class);
+
+    Assert.assertEquals(consumerRecords.size(), 1);
+
+    Metric after = consumerRecords.get(0).value();
+
+    Assert.assertEquals(before.getMetricType(), after.getMetricType());
+
+    Assert.assertEquals(
+      before.getMetricData().get(Fields.SystemMetrics.UPTIME.toString()),
+      after.getMetricData().get(Fields.SystemMetrics.UPTIME.toString())
+    );
+
+    Assert.assertEquals(
+      before.getMetricData().get(Fields.SystemMetrics.DATETIME.toString()),
+      after.getMetricData().get(Fields.SystemMetrics.DATETIME.toString())
+    );
+  }
+
+  @Test
+  public void testProduceConsumeViaKafka() throws InterruptedException {
+    String kafkaBroker = kafka.getKafkaConnectString();
     List<String> brokers = Collections.singletonList(kafkaBroker);
     MetricsProducer os = new OSMetricsProducer(brokers, topic);
 
@@ -56,6 +105,7 @@ public class KafkaTest {
       while (Instant.now().toEpochMilli() < endTime) {Thread.sleep(1000);}
     } finally {
       os.shutdown();
+      Thread.sleep(1000);
       listener.stop();
     }
 

--- a/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/KafkaTest.java
+++ b/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/KafkaTest.java
@@ -1,0 +1,82 @@
+package edu.marist.mscs710.metricscollector;
+
+import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
+import edu.marist.mscs710.metricscollector.kafka.KafkaConfig;
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+import edu.marist.mscs710.metricscollector.producer.OSMetricsProducer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class KafkaTest {
+
+  @ClassRule
+  public static final SharedKafkaTestResource kafka = new SharedKafkaTestResource();
+
+  @Test
+  public void testSerializeDeserialize() throws InterruptedException {
+    String kafkaBroker = kafka.getKafkaConnectString();
+
+    String topic = "test-topic-embedded";
+    List<String> brokers = Collections.singletonList(kafkaBroker);
+    MetricsProducer os = new OSMetricsProducer(brokers, topic);
+
+    Map<MetricType, Set<String>> metricsFields = new HashMap<MetricType, Set<String>>() {
+      {
+        put(MetricType.CPU, toStringSet(Fields.Cpu.values()));
+        put(MetricType.CPU_CORE, toStringSet(Fields.CpuCore.values()));
+        put(MetricType.MEMORY, toStringSet(Fields.Memory.values()));
+        put(MetricType.NETWORK, toStringSet(Fields.Network.values()));
+        put(MetricType.PROCESSES, toStringSet(Fields.Processes.values()));
+        put(MetricType.SYSTEM_CONSTANTS, toStringSet(Fields.SystemConstants.values()));
+        put(MetricType.SYSTEM_METRICS, toStringSet(Fields.SystemMetrics.values()));
+      }
+    };
+
+    List<Metric> metrics = new ArrayList<>();
+
+    Consumer<ConsumerRecord<String, Metric>> dataConsumer = (m) -> metrics.add(m.value());
+
+    KafkaMessageListenerContainer<String, Metric> listener =
+      KafkaConfig.createListener(brokers, "TEST_GROUP", topic, dataConsumer);
+
+    try {
+      os.start();
+      listener.start();
+      long endTime = Instant.now().toEpochMilli() + 1000 * 15;
+      while (Instant.now().toEpochMilli() < endTime) {Thread.sleep(1000);}
+    } finally {
+      os.shutdown();
+      listener.stop();
+    }
+
+    Assert.assertTrue(metrics.size() > 0);
+
+    for (Metric metric : metrics) {
+      Assert.assertNotSame(metric.getMetricType(), MetricType.NULL);
+      MetricType type = metric.getMetricType();
+      Map<String, Object> metricData = metric.getMetricData();
+      Set<String> fields = metricsFields.get(type);
+
+      for (String field : metricData.keySet()) {
+        Assert.assertTrue(fields.contains(field));
+      }
+    }
+  }
+
+
+  public static <E extends Enum<E>> Set<String> toStringSet(E[] enumValues) {
+    return Arrays.stream(enumValues)
+      .map(Enum::toString)
+      .collect(Collectors.toSet());
+  }
+}

--- a/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/KafkaUtilsTest.java
+++ b/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/KafkaUtilsTest.java
@@ -1,0 +1,36 @@
+package edu.marist.mscs710.metricscollector;
+
+import edu.marist.mscs710.metricscollector.kafka.MetricDeserializer;
+import edu.marist.mscs710.metricscollector.kafka.MetricSerializer;
+import edu.marist.mscs710.metricscollector.metric.Fields;
+import edu.marist.mscs710.metricscollector.metric.Metric;
+import edu.marist.mscs710.metricscollector.metric.MetricType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class KafkaUtilsTest {
+
+  @Test
+  public void testMetricSerializerDeserializer() {
+    Metric before = new Metric(MetricType.SYSTEM_METRICS, new HashMap<String, Object>(){{
+      put(Fields.SystemMetrics.UPTIME.toString(), 999999);
+      put(Fields.SystemMetrics.DATETIME.toString(), 111111);
+    }});
+
+    Metric after = new MetricDeserializer().deserialize("", new MetricSerializer().serialize("", before));
+
+    Assert.assertEquals(before.getMetricType(), after.getMetricType());
+
+    Assert.assertEquals(
+      before.getMetricData().get(Fields.SystemMetrics.UPTIME.toString()),
+      after.getMetricData().get(Fields.SystemMetrics.UPTIME.toString())
+    );
+
+    Assert.assertEquals(
+      before.getMetricData().get(Fields.SystemMetrics.DATETIME.toString()),
+      after.getMetricData().get(Fields.SystemMetrics.DATETIME.toString())
+    );
+  }
+}

--- a/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/TestCodeFile.java
+++ b/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/TestCodeFile.java
@@ -1,4 +1,0 @@
-package edu.marist.mscs710.metricscollector;
-
-public class TestCodeFile {
-}

--- a/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/TestMetrics.java
+++ b/resource-monitor/metrics-collector/src/test/java/edu/marist/mscs710/metricscollector/TestMetrics.java
@@ -1,0 +1,185 @@
+package edu.marist.mscs710.metricscollector;
+
+import edu.marist.mscs710.metricscollector.data.MemoryData;
+import edu.marist.mscs710.metricscollector.data.NetworkData;
+import edu.marist.mscs710.metricscollector.data.ProcessData;
+import edu.marist.mscs710.metricscollector.system.Cpu;
+import edu.marist.mscs710.metricscollector.system.Memory;
+import edu.marist.mscs710.metricscollector.system.Network;
+import edu.marist.mscs710.metricscollector.system.Processes;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import oshi.SystemInfo;
+import oshi.hardware.NetworkIF;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class TestMetrics {
+
+  @Test
+  public void testGetCpuCoreUsages() throws InterruptedException {
+    Cpu cpu = new Cpu(true);
+
+    Thread.sleep(300);
+
+    double[] perCoreCpuUsages = cpu.getMetricData().get(0).getCpuCoreUsages();
+
+    int numPhysCores = new SystemInfo().getHardware().getProcessor().getPhysicalProcessorCount();
+
+    Assert.assertEquals(numPhysCores, perCoreCpuUsages.length);
+
+    for (double pct : perCoreCpuUsages) {
+      Assert.assertTrue(pct >= 0 && pct <= 1);
+    }
+  }
+
+  @Test
+  public void testMemoryData() throws InterruptedException {
+    Memory memory = new Memory();
+
+    Thread.sleep(500);
+
+    MemoryData memData = memory.getMetricData().get(0);
+
+    Assert.assertTrue(memData.getMemoryUtilization() > 0 && memData.getMemoryUtilization() < 1.0);
+    Assert.assertTrue(memData.getPageFaults() >= 0);
+    Assert.assertTrue(memData.getDeltaMillis() > 0);
+
+    Thread.sleep(500);
+
+    MemoryData newData = memory.getMetricData().get(0);
+
+    Assert.assertTrue(newData.getDeltaMillis() > 0);
+    Assert.assertTrue(newData.getEpochMillisTime() > memData.getEpochMillisTime());
+    Assert.assertTrue(newData.getPageFaults() >= 0);
+    Assert.assertTrue(newData.getMemoryUtilization() > 0 && newData.getMemoryUtilization() < 1.0);
+  }
+
+  @Test
+  @Ignore
+  public void viewNetwork() throws InterruptedException {
+    Network network = new Network();
+    NetworkIF[] nets = new SystemInfo().getHardware().getNetworkIFs();
+
+    for (int i = 0; i < 5; i++) {
+      System.out.println();
+
+      for (NetworkIF n : nets) {
+        System.out.println(n.getDisplayName() + ": " + n.getBytesRecv() + " bytes rec, " + n.getBytesSent() + " bytes sent, " + n.getSpeed() + " speed");
+      }
+
+      System.out.println();
+
+      NetworkData netData = network.getMetricData().get(0);
+
+      System.out.println(String.format("Bytes Sent: %s, bytes recv: %s, bit / s: %s, delta millis: %s",
+        netData.getBytesSent(), netData.getBytesRecv(), netData.getSpeed(), netData.getDeltaMillis()));
+
+      Thread.sleep(2000);
+      for (NetworkIF n : nets)
+        n.updateAttributes();
+    }
+  }
+
+  @Test
+  @Ignore
+  public void viewProcesses() throws InterruptedException {
+    SystemInfo sys = new SystemInfo();
+    OperatingSystem os = sys.getOperatingSystem();
+
+    OSProcess[] processes;
+
+    System.out.println(String.format("Current seconds: %s, Millis: %s", Instant.now().getEpochSecond(), Instant.now().toEpochMilli()));
+    System.out.println();
+
+    int cpus = sys.getHardware().getProcessor().getLogicalProcessorCount(); // We want to do this on Windows, haven't tested whether this is correct
+                                                                            // for Linux.
+
+    for (int i = 0; i < 3; i++) {
+
+      processes = os.getProcesses(10, OperatingSystem.ProcessSort.PID);
+
+      for (OSProcess p : processes) {
+        System.out.println(String.format("PID: %s, CPU: %s, Uptime: %s, Start: %s, Name: %s, Memory: %s",
+          p.getProcessID(), p.calculateCpuPercent() / cpus, p.getUpTime(), p.getStartTime(), p.getName(), p.getResidentSetSize()));
+      }
+
+      System.out.println();
+
+      Thread.sleep(2000);
+    }
+  }
+
+  @Test
+  @Ignore
+  public void viewGetProcesses() throws InterruptedException {
+    Processes processes = new Processes();
+
+    for (int j = 0; j < 2; j++) {
+
+      Thread.sleep(2500);
+      System.out.println();
+      System.out.println("EpochMillis: " + Instant.now().toEpochMilli());
+      System.out.println();
+
+      List<ProcessData> processDataList = processes.getMetricData();
+
+      System.out.println(processDataList.size());
+
+      for (int i = 0; i < 10; i++) {
+        System.out.println(processDataList.get(i).toString());
+      }
+      System.out.println(processDataList.get(processDataList.size() - 1).toString());
+      System.out.println();
+    }
+  }
+
+  @Test
+  public void testGetProcesses() throws InterruptedException {
+    Processes processes = new Processes();
+    Thread.sleep(1000);
+
+    List<ProcessData> pdl = processes.getMetricData();
+
+    Assert.assertEquals(1.0, pdl.stream().mapToDouble(ProcessData::getCpuUsage).sum(), 0.05);
+
+    Map<Integer, ProcessData> priorProcs = pdl.stream().filter(Objects::nonNull)
+      .collect(Collectors.toMap(ProcessData::getPid, Function.identity()));
+
+    Thread.sleep(2000);
+
+    pdl = processes.getMetricData();
+    Assert.assertEquals(1.0, pdl.stream().mapToDouble(ProcessData::getCpuUsage).sum(), 0.05);
+
+    for (ProcessData pd : pdl) {
+      Processes.PidState state = pd.getPidState();
+      ProcessData prior = priorProcs.get(pd.getPid());
+
+      switch (state) {
+        case RUNNING:
+          Assert.assertNotNull(prior);
+          Assert.assertEquals(pd.getStartTime(), prior.getStartTime());
+          Assert.assertTrue(pd.getUpTime() > prior.getUpTime());
+          break;
+        case RECYCLED:
+          Assert.assertNotNull(prior);
+          Assert.assertTrue(pd.getStartTime() > prior.getStartTime());
+          break;
+        case NEW:
+          Assert.assertNull(prior);
+          break;
+        case ENDED:
+          Assert.assertNotNull(prior);
+          break;
+      }
+    }
+  }
+}

--- a/resource-monitor/metrics-persistence-api/src/main/resources/db_schema.sql
+++ b/resource-monitor/metrics-persistence-api/src/main/resources/db_schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE CPU_Core (
                              NOT NULL,
     Core_Id          INTEGER NOT NULL,
     Core_Utilization REAL    NOT NULL,
-    Core_Temp        INTEGER NOT NULL
+    Core_Temp        INTEGER NOT NULL -- No core temp
 );
 
 
@@ -59,8 +59,8 @@ CREATE TABLE Processess (
     Rec_Id       INTEGER PRIMARY KEY AUTOINCREMENT,
     PID          INTEGER NOT NULL,
     Process_Name TEXT    NOT NULL,
-    Start_Time   BIGINT  NOT NULL,
-    End_Time     BIGINT,
+    Start_Time   BIGINT  NOT NULL, -- OSHI start time given in millis, value returned has varied by +- 1
+    End_Time     BIGINT, -- Planning to make this uptime in millis instead
     metrics      BLOB    NOT NULL
 );
 

--- a/resource-monitor/pom.xml
+++ b/resource-monitor/pom.xml
@@ -22,12 +22,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/resource-monitor/pom.xml
+++ b/resource-monitor/pom.xml
@@ -19,9 +19,21 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <kafka.version>2.4.0</kafka.version>
         <kafka-scala.version>2.12</kafka-scala.version>
+        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I don't have a main entrypoint yet, but I can add that quick soon. Wanted to check this in and get working on updating the build for Wednesday. 

Sorry, I know this is a ton of new code to review. Check out the test functions to see what's going on overall. OSMetricsProducer spawns a new thread to collect and send metrics at regular intervals.  I am not currently using a lot of the MetricsProducer interface methods. I figured they would be useful if we have time to implement error handling or backing off metrics production in the case of failure or backlogging, something like that. 

There are some @Ignore test methods in TestMetrics that don't actually test anything programatically. I was using to view the output of the "system" package objects. You can view those if you want to see what some of the metric sources are doing. 

In the "metric" package I have enums of MetricType and Fields, you can look there for the fields and descriptions of what I'm currently sending. Let me know if you want me to add or change anything for what you've been working on for the UI. You should be able to deserialize with json and get the metricData fields by keeping a schema locally by metricType. 